### PR TITLE
Only allow valid datasets

### DIFF
--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -19,7 +19,7 @@ from tasks.implementations.info import Info
 from tasks.implementations.publish_findings_task import PublishFindingsTask
 from tasks.implementations.publish_metadata_task import PublishMetadataTask
 from utils import command_line_util
-from utils.dataset_util import get_white_list
+from utils.dataset_util import get_available_datasets, get_white_list
 from utils.logging import IndentFormatter
 
 MUBENCH_ROOT_PATH = join(dirname(abspath(__file__)), os.pardir)
@@ -135,7 +135,8 @@ class Benchmark:
 
 available_detectors = get_available_detector_ids(Benchmark.DETECTORS_PATH)
 available_scripts = stats.get_available_calculator_names()
-config = command_line_util.parse_args(sys.argv, available_detectors, available_scripts)
+available_datasets = get_available_datasets(Benchmark.DATASETS_FILE_PATH)
+config = command_line_util.parse_args(sys.argv, available_detectors, available_scripts, available_datasets)
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)

--- a/mubench.pipeline/tests/utils/test_command_line_util.py
+++ b/mubench.pipeline/tests/utils/test_command_line_util.py
@@ -4,122 +4,126 @@ from utils.command_line_util import get_command_line_parser
 
 
 def test_invalid_mode():
-    parser = get_command_line_parser([], [])
+    parser = get_command_line_parser([], [], [])
     assert_raises(SystemExit, parser.parse_args, ['invalid'])
 
 
 def test_mode_check():
-    parser = get_command_line_parser([], [])
+    parser = get_command_line_parser([], [], [])
     result = parser.parse_args(['check'])
     assert result.task == 'check'
 
 
 def test_checkout():
-    parser = get_command_line_parser([], [])
+    parser = get_command_line_parser([], [], [])
     result = parser.parse_args(['checkout'])
     assert result.task == 'checkout'
 
 
 def test_detect_fails_without_detector():
-    parser = get_command_line_parser([], [])
+    parser = get_command_line_parser([], [], [])
     assert_raises(SystemExit, parser.parse_args, ['detect'])
 
 
 def test_detect_fails_without_experiment():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     assert_raises(SystemExit, parser.parse_args, ['detect', 'valid-detector'])
 
 
 def test_detect_valid():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     result = parser.parse_args(['detect', 'valid-detector', '1'])
     assert result.detector == 'valid-detector'
 
 
 def test_detect_only_empty_list_fails():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     assert_raises(SystemExit, parser.parse_args, ['detect', 'valid-detector', '--only'])
 
 
 def test_detect_only():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     white_list = ['a', 'b', 'c']
     result = parser.parse_args(['detect', 'valid-detector', '1', '--only'] + white_list)
     assert result.white_list == white_list
 
 
 def test_detect_only_default():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     result = parser.parse_args(['detect', 'valid-detector', '1'])
     assert result.white_list == []
 
 
 def test_detect_ignore_empty_list_fails():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     assert_raises(SystemExit, parser.parse_args, ['detect', 'valid-detector', '--skip'])
 
 
 def test_detect_ignore():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     black_list = ['a', 'b', 'c']
     result = parser.parse_args(['detect', 'valid-detector', '1', '--skip'] + black_list)
     assert result.black_list == black_list
 
 
 def test_detect_ignore_default():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     result = parser.parse_args(['detect', 'valid-detector', '1'])
     assert result.black_list == []
 
 
 def test_detect_timeout():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     value = '100'
     result = parser.parse_args(['detect', 'valid-detector', '1', '--timeout', value])
     assert result.timeout == int(value)
 
 
 def test_detect_experiment_is_int():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     result = parser.parse_args(['detect', 'valid-detector', '1'])
     assert_equals(int, type(result.experiment))
 
 
 def test_timeout_default_none():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     result = parser.parse_args(['detect', 'valid-detector', '1'])
     assert result.timeout is None
 
 
 def test_timeout_non_int_fails():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     assert_raises(SystemExit, parser.parse_args, ['detect', 'valid-detector', '1', '--timeout', 'string'])
 
 
 @nottest
 def test_detect_fails_for_invalid_detector():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     assert_raises(SystemExit, parser.parse_args, ['detect', 'invalid-detector'])
 
 
 def test_java_options():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     result = parser.parse_args(['detect', 'valid-detector', '1', '--java-options', 'Xmx6144M', 'd64'])
     assert_equals(['Xmx6144M', 'd64'], result.java_options)
 
 
 def test_java_options_default_empty():
-    parser = get_command_line_parser(['valid-detector'], [])
+    parser = get_command_line_parser(['valid-detector'], [], [])
     result = parser.parse_args(['detect', 'valid-detector', '1'])
     assert_equals([], result.java_options)
 
 
 def test_script_is_case_insensitive():
-    parser = get_command_line_parser([], ['GENERAL'])
+    parser = get_command_line_parser([], ['GENERAL'], [])
     parser.parse_args(['stats', 'general'])
 
 
 def test_dataset():
-    parser = get_command_line_parser(['Dummy'], [])
-    result = parser.parse_args(['detect', 'Dummy', '1', '--dataset', 'crypto'])
-    assert_equals('crypto', result.dataset)
+    parser = get_command_line_parser(['Dummy'], [], ['valid-dataset'])
+    result = parser.parse_args(['detect', 'Dummy', '1', '--dataset', 'valid-dataset'])
+    assert_equals('valid-dataset', result.dataset)
+
+def test_fails_for_invalid_dataset():
+    parser = get_command_line_parser(['valid-detector'], [], ['valid-dataset'])
+    assert_raises(SystemExit, parser.parse_args, ['detect', 'valid-detector', '1', '--dataset', 'invalid-dataset'])

--- a/mubench.pipeline/utils/dataset_util.py
+++ b/mubench.pipeline/utils/dataset_util.py
@@ -2,6 +2,9 @@ from typing import List, Optional
 
 from utils.io import read_yaml
 
+def get_available_datasets(datasets_file_path: str) -> List[str]:
+    datasets = read_yaml(datasets_file_path)
+    return datasets.keys()
 
 def get_white_list(datasets_file_path: str, dataset_key: Optional[str]) -> List[str]:
     if dataset_key is None:

--- a/mubench.pipeline/utils/dataset_util.py
+++ b/mubench.pipeline/utils/dataset_util.py
@@ -4,7 +4,7 @@ from utils.io import read_yaml
 
 def get_available_datasets(datasets_file_path: str) -> List[str]:
     datasets = read_yaml(datasets_file_path)
-    return datasets.keys()
+    return list(datasets.keys())
 
 def get_white_list(datasets_file_path: str, dataset_key: Optional[str]) -> List[str]:
     if dataset_key is None:


### PR DESCRIPTION
We now use choices for the --dataset CLI option, which makes for a cleaner error output.