### PR TITLE
Interface changelogs and legacy checks

### DIFF
--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -102,8 +102,9 @@ class Benchmark:
     def __get_detector(self):
         try:
             java_options = ['-' + option for option in self.config.java_options]
-            return find_detector(self.DETECTORS_PATH, self.config.detector, java_options, self.config.requested_release)
-        except ValueError as e:
+            return find_detector(self.DETECTORS_PATH, self.config.detector, java_options,
+                    self.config.requested_release)
+        except Exception as e:
             logger.critical(e)
             exit()
 

--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -103,7 +103,7 @@ class Benchmark:
         try:
             java_options = ['-' + option for option in self.config.java_options]
             return find_detector(self.DETECTORS_PATH, self.config.detector, java_options,
-                    self.config.requested_release)
+                                 self.config.requested_release)
         except Exception as e:
             logger.critical(e)
             exit()

--- a/mubench.pipeline/data/detector.py
+++ b/mubench.pipeline/data/detector.py
@@ -1,3 +1,4 @@
+from distutils.version import StrictVersion
 from logging import Logger
 from os.path import join, exists
 from typing import Dict, Optional, List
@@ -21,7 +22,7 @@ class Detector:
         release_tag = release.get("tag", "latest")
 
         if "cli_version" in release:
-            cli_version = release["cli_version"]
+            cli_version = StrictVersion(release["cli_version"])
         else:
             raise ValueError("Missing CLI version for {}".format(detector_id))
 

--- a/mubench.pipeline/data/detector_execution.py
+++ b/mubench.pipeline/data/detector_execution.py
@@ -85,7 +85,7 @@ class DetectorExecution:
         try:
             self.detector.execute(self.version, detector_args, timeout, logger)
             result = Result.success
-        except (CommandFailedError, NoCompatibleRunnerInterface) as e:
+        except CommandFailedError as e:
             logger.error("Detector failed: %s", e)
             result = Result.error
             message = str(e)

--- a/mubench.pipeline/data/runner_interface.py
+++ b/mubench.pipeline/data/runner_interface.py
@@ -85,17 +85,6 @@ class RunnerInterface:
         return sorted(versions)[-1]
 
 
-class NoInterface():
-    def __init__(self, requested_cli_version: StrictVersion):
-        self._requested_cli_version = requested_cli_version
-
-    def execute(self, *_):
-        raise NoCompatibleRunnerInterface(self._requested_cli_version)
-
-    def is_legacy(self):
-        return False
-
-
 class RunnerInterface_0_0_8(RunnerInterface):
     _VALID_KEYS = [
         "target",

--- a/mubench.pipeline/data/runner_interface.py
+++ b/mubench.pipeline/data/runner_interface.py
@@ -30,7 +30,7 @@ class RunnerInterface:
         except ValueError:
             return NoInterface(cli_version)
 
-        interfaces = RunnerInterface.__subclasses__()
+        interfaces = RunnerInterface._get_interfaces()
         matching_interfaces = [i for i in interfaces if i.version() == cli_version]
         if matching_interfaces:
             return matching_interfaces[0](jar_path, java_options)
@@ -53,9 +53,13 @@ class RunnerInterface:
         return self.version() < self.__get_latest_version()
 
     @staticmethod
+    def _get_interfaces() -> List['RunnerInterface']:
+        return RunnerInterface.__subclasses__()
+
+    @staticmethod
     def __get_latest_version() -> StrictVersion:
-        versions = [interface.version() for interface in
-                RunnerInterface.__subclasses__()]
+        versions = [interface.version() for interface in \
+                RunnerInterface._get_interfaces()]
         return sorted(versions)[-1]
 
 

--- a/mubench.pipeline/data/runner_interface.py
+++ b/mubench.pipeline/data/runner_interface.py
@@ -40,7 +40,7 @@ class RunnerInterface:
         if matching_interfaces:
             return matching_interfaces[0](jar_path, java_options)
         else:
-            return NoInterface(requested_version)
+            raise NoCompatibleRunnerInterface(requested_version)
 
     @staticmethod
     def version() -> StrictVersion:

--- a/mubench.pipeline/data/runner_interface.py
+++ b/mubench.pipeline/data/runner_interface.py
@@ -29,18 +29,13 @@ class RunnerInterface:
             self._log_legacy_warning()
 
     @staticmethod
-    def get(cli_version: str, jar_path: str, java_options: List[str]) -> 'RunnerInterface':
-        try:
-            requested_version = StrictVersion(cli_version)
-        except ValueError:
-            return NoInterface(cli_version)
-
+    def get(requested_version: StrictVersion, jar_path: str, java_options: List[str]) -> 'RunnerInterface':
         interfaces = RunnerInterface._get_interfaces()
-        matching_interfaces = [i for i in interfaces if i.version() == cli_version]
+        matching_interfaces = [i for i in interfaces if i.version() == requested_version]
         if matching_interfaces:
             return matching_interfaces[0](jar_path, java_options)
         else:
-            return NoInterface(cli_version)
+            return NoInterface(requested_version)
 
     @staticmethod
     def version() -> StrictVersion:
@@ -86,7 +81,7 @@ class RunnerInterface:
 
 
 class NoInterface():
-    def __init__(self, requested_cli_version: str):
+    def __init__(self, requested_cli_version: StrictVersion):
         self._requested_cli_version = requested_cli_version
 
     def execute(self, *_):
@@ -147,5 +142,5 @@ class RunnerInterface_0_0_8(RunnerInterface):
         return args
 
 class NoCompatibleRunnerInterface(Exception):
-    def __init__(self, version: str):
+    def __init__(self, version: StrictVersion):
         super().__init__("No compatible runner interface for version {}".format(version))

--- a/mubench.pipeline/data/runner_interface.py
+++ b/mubench.pipeline/data/runner_interface.py
@@ -41,6 +41,10 @@ class RunnerInterface:
     def version() -> StrictVersion:
         raise NotImplementedError
 
+    @staticmethod
+    def changelog() -> str:
+        raise NotImplementedError
+
     def execute(self, version: ProjectVersion, detector_arguments: Dict[str, str],
                 timeout: Optional[int], logger: Logger):
         raise NotImplementedError
@@ -81,6 +85,10 @@ class RunnerInterface_0_0_8(RunnerInterface):
     @staticmethod
     def version() -> StrictVersion:
         return StrictVersion("0.0.8")
+
+    @staticmethod
+    def changelog() -> str:
+        return "Oldest version."
 
     def execute(self, version: ProjectVersion, detector_arguments: Dict[str, str],
                 timeout: Optional[int], logger: Logger):

--- a/mubench.pipeline/data/runner_interface.py
+++ b/mubench.pipeline/data/runner_interface.py
@@ -19,6 +19,11 @@ def _as_list(dictionary: Dict) -> List:
     return l
 
 
+class NoCompatibleRunnerInterface(Exception):
+    def __init__(self, version: StrictVersion):
+        super().__init__("No compatible runner interface for version {}".format(version))
+
+
 class RunnerInterface:
     def __init__(self, jar_path: str, java_options: List[str]):
         self.jar_path = jar_path
@@ -140,7 +145,3 @@ class RunnerInterface_0_0_8(RunnerInterface):
         for key, value in detector_arguments.items():
             args[key] = _quote(value)
         return args
-
-class NoCompatibleRunnerInterface(Exception):
-    def __init__(self, version: StrictVersion):
-        super().__init__("No compatible runner interface for version {}".format(version))

--- a/mubench.pipeline/tasks/implementations/detect.py
+++ b/mubench.pipeline/tasks/implementations/detect.py
@@ -51,9 +51,7 @@ class Detect(ProjectVersionTask):
         file = self.detector.jar_path
 
         try:
-            if not exists(self.detector.md5_path):
-                raise FileNotFoundError("Cannot validate download, MD5-checksum file '{}' missing".format(self.detector.md5_path))
-            download_file(url, file, self.detector.md5_path)
+            download_file(url, file, self.detector.md5)
         except (FileNotFoundError, ValueError, URLError) as e:
             logger.error("Download failed: %s", e)
             exit(1)

--- a/mubench.pipeline/tests/data/test_detector.py
+++ b/mubench.pipeline/tests/data/test_detector.py
@@ -25,13 +25,13 @@ class TestDetector:
         assert_raises(ValueError, Detector, self.temp_dir, self.detector_id, [])
 
     def test_md5(self):
-        self.setup_releases([{"md5": "-md5-", "cli_version": "-version-"}])
+        self.setup_releases([{"md5": "-md5-", "cli_version": "0.0.0"}])
         detector = Detector(self.temp_dir, self.detector_id, [])
 
         assert_equals("-md5-", detector.md5)
 
     def test_raises_on_missing_md5(self):
-        self.setup_releases([{"cli_version": "-version-"}])
+        self.setup_releases([{"cli_version": "0.0.0"}])
         assert_raises(ValueError, Detector, self.temp_dir, self.detector_id, [])
 
     def test_interface(self):
@@ -45,25 +45,25 @@ class TestDetector:
         assert_raises(ValueError, Detector, self.temp_dir, self.detector_id, [])
 
     def test_download_url(self):
-        self.setup_releases([{"cli_version": "-version-", "tag": "-tag-", "md5": "-md5-"}])
+        self.setup_releases([{"cli_version": "0.0.1", "tag": "-tag-", "md5": "-md5-"}])
         detector = Detector(self.temp_dir, self.detector_id, [])
 
-        expected_url = "{}/-tag-/-version-/{}.jar".format(Detector.BASE_URL, self.detector_id)
+        expected_url = "{}/-tag-/0.0.1/{}.jar".format(Detector.BASE_URL, self.detector_id)
         assert_equals(expected_url, detector.jar_url)
 
     def test_gets_requested_release(self):
         self.setup_releases([
-                    {"md5": "-md5_1-", "tag": "-release_1-", "cli_version": "-version_1-"},
-                    {"md5": "-md5_requested-", "tag": "-release_requested-", "cli_version": "-version_requested-"},
-                    {"md5": "-md5_3-", "tag": "-release_3-", "cli_version": "-version_3-"}])
+                    {"md5": "-md5_1-", "tag": "-release_1-", "cli_version": "0.0.0"},
+                    {"md5": "-md5_requested-", "tag": "-release_requested-", "cli_version": "0.0.1"},
+                    {"md5": "-md5_3-", "tag": "-release_3-", "cli_version": "0.0.2"}])
         detector = Detector(self.temp_dir, self.detector_id, [], "-release_requested-")
 
-        expected_url = "{}/-release_requested-/-version_requested-/{}.jar".format(Detector.BASE_URL, self.detector_id)
+        expected_url = "{}/-release_requested-/0.0.1/{}.jar".format(Detector.BASE_URL, self.detector_id)
         assert_equals(expected_url, detector.jar_url)
         assert_equals("-md5_requested-", detector.md5)
 
     def test_raises_on_no_matching_release(self):
-        self.setup_releases([{"md5": "-md5-", "tag": "-release-", "cli_version": "-version-"}])
+        self.setup_releases([{"md5": "-md5-", "tag": "-release-", "cli_version": "0.0.1"}])
         assert_raises(ValueError, Detector, self.temp_dir, self.detector_id, [], "-unavailable_release-")
 
     def setup_releases(self, releases):

--- a/mubench.pipeline/tests/data/test_detector.py
+++ b/mubench.pipeline/tests/data/test_detector.py
@@ -5,7 +5,6 @@ from nose.tools import assert_equals, assert_is_instance, assert_raises
 from tests.test_utils.runner_interface_test_impl import RunnerInterfaceTestImpl
 
 from data.detector import Detector
-from data.runner_interface import NoInterface
 from utils.io import remove_tree, write_yaml
 
 

--- a/mubench.pipeline/tests/data/test_detector.py
+++ b/mubench.pipeline/tests/data/test_detector.py
@@ -25,13 +25,14 @@ class TestDetector:
         assert_raises(ValueError, Detector, self.temp_dir, self.detector_id, [])
 
     def test_md5(self):
-        self.setup_releases([{"md5": "-md5-", "cli_version": "0.0.0"}])
+        self.setup_releases([{"md5": "-md5-",
+            "cli_version": RunnerInterfaceTestImpl.TEST_VERSION}])
         detector = Detector(self.temp_dir, self.detector_id, [])
 
         assert_equals("-md5-", detector.md5)
 
     def test_raises_on_missing_md5(self):
-        self.setup_releases([{"cli_version": "0.0.0"}])
+        self.setup_releases([{"cli_version": RunnerInterfaceTestImpl.TEST_VERSION}])
         assert_raises(ValueError, Detector, self.temp_dir, self.detector_id, [])
 
     def test_interface(self):
@@ -45,20 +46,24 @@ class TestDetector:
         assert_raises(ValueError, Detector, self.temp_dir, self.detector_id, [])
 
     def test_download_url(self):
-        self.setup_releases([{"cli_version": "0.0.1", "tag": "-tag-", "md5": "-md5-"}])
+        self.setup_releases(
+                [{"cli_version": RunnerInterfaceTestImpl.TEST_VERSION, "tag": "-tag-", "md5": "-md5-"}])
         detector = Detector(self.temp_dir, self.detector_id, [])
 
-        expected_url = "{}/-tag-/0.0.1/{}.jar".format(Detector.BASE_URL, self.detector_id)
+        expected_url = "{}/-tag-/{}/{}.jar".format(Detector.BASE_URL,
+                RunnerInterfaceTestImpl.TEST_VERSION, self.detector_id)
         assert_equals(expected_url, detector.jar_url)
 
     def test_gets_requested_release(self):
         self.setup_releases([
                     {"md5": "-md5_1-", "tag": "-release_1-", "cli_version": "0.0.0"},
-                    {"md5": "-md5_requested-", "tag": "-release_requested-", "cli_version": "0.0.1"},
+                    {"md5": "-md5_requested-", "tag": "-release_requested-",
+                        "cli_version": RunnerInterfaceTestImpl.TEST_VERSION},
                     {"md5": "-md5_3-", "tag": "-release_3-", "cli_version": "0.0.2"}])
         detector = Detector(self.temp_dir, self.detector_id, [], "-release_requested-")
 
-        expected_url = "{}/-release_requested-/0.0.1/{}.jar".format(Detector.BASE_URL, self.detector_id)
+        expected_url = "{}/-release_requested-/{}/{}.jar".format(Detector.BASE_URL,
+                RunnerInterfaceTestImpl.TEST_VERSION, self.detector_id)
         assert_equals(expected_url, detector.jar_url)
         assert_equals("-md5_requested-", detector.md5)
 

--- a/mubench.pipeline/tests/data/test_detector_execution.py
+++ b/mubench.pipeline/tests/data/test_detector_execution.py
@@ -12,6 +12,7 @@ from data.findings_filters import PotentialHits, AllFindings, FindingsFilter
 from data.project_compile import ProjectCompile
 from tests.data.stub_detector import StubDetector
 from tests.test_utils.data_util import create_misuse, create_version, create_project
+from tests.test_utils.runner_interface_test_impl import RunnerInterfaceTestImpl
 from utils.io import remove_tree
 from utils.shell import CommandFailedError
 

--- a/mubench.pipeline/tests/data/test_detector_execution.py
+++ b/mubench.pipeline/tests/data/test_detector_execution.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch, ANY
 from nose.tools import assert_equals
 
 from data.detector_execution import DetectOnlyExecution, MineAndDetectExecution, Result, DetectorExecution, DetectorMode
-from data.runner_interface import NoInterface
 from data.finding import Finding
 from data.findings_filters import PotentialHits, AllFindings, FindingsFilter
 from data.project_compile import ProjectCompile
@@ -135,21 +134,6 @@ class TestDetectorExecution:
 
         write_yaml_mock.assert_called_with(
             {'result': 'success', 'message': '', 'md5': self.detector.md5, 'runtime': ANY},
-            file='-findings-/run.yml'
-        )
-
-    def test_result_error_when_missing_runner_interface(self, write_yaml_mock):
-        self.detector.runner_interface = NoInterface("-cli_version-")
-
-        self.uut.execute("-compiles", 42, self.logger)
-
-        write_yaml_mock.assert_called_with(
-            {
-                'result': 'error',
-                'message': "No compatible runner interface for version -cli_version-",
-                'md5': self.detector.md5,
-                'runtime': ANY
-            },
             file='-findings-/run.yml'
         )
 

--- a/mubench.pipeline/tests/data/test_runner_interface.py
+++ b/mubench.pipeline/tests/data/test_runner_interface.py
@@ -1,11 +1,12 @@
 import logging
 from collections import OrderedDict
+from distutils.version import StrictVersion
 from os.path import join
 from tempfile import mkdtemp
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from nose.tools import assert_equals, assert_true, assert_raises
+from nose.tools import assert_equals, assert_true, assert_false, assert_raises
 
 from data.runner_interface import NoInterface, RunnerInterface, RunnerInterface_0_0_8, NoCompatibleRunnerInterface
 from tests.data.stub_detector import StubDetector
@@ -22,6 +23,21 @@ class TestRunnerInterface:
     def test_get_interface_version_default_for_unavailable_version(self):
         actual = RunnerInterface.get("-unavailable_version-", "", dict())
         assert_true(isinstance(actual, NoInterface))
+
+    def test_interface_is_legacy(self):
+        class LatestInterface(RunnerInterface): pass
+        LatestInterface.version = lambda *_: StrictVersion("1000.0.0")
+        class LegacyInterface(RunnerInterface): pass
+        LegacyInterface.version = lambda *_: StrictVersion("0.0.0")
+
+        assert_true(LegacyInterface("", []).is_legacy())
+
+    def test_latest_interface_is_not_legacy(self):
+        class LatestInterface(RunnerInterface): pass
+        LatestInterface.version = lambda *_: StrictVersion("1000.0.0")
+
+        assert_false(LatestInterface("", []).is_legacy())
+
 
 class TestNoInterface:
     def test_execute_raises_exception(self):

--- a/mubench.pipeline/tests/data/test_runner_interface.py
+++ b/mubench.pipeline/tests/data/test_runner_interface.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 from nose.tools import assert_equals, assert_true, assert_false, assert_raises
 
-from data.runner_interface import NoInterface, RunnerInterface, RunnerInterface_0_0_8, NoCompatibleRunnerInterface
+from data.runner_interface import RunnerInterface, RunnerInterface_0_0_8, NoCompatibleRunnerInterface
 from tests.data.stub_detector import StubDetector
 from utils.io import remove_tree, write_yaml
 from utils.shell import Shell, CommandFailedError
@@ -51,18 +51,6 @@ class TestRunnerInterface:
 
         assert_false(LatestInterface("", []).is_legacy())
 
-
-class TestNoInterface:
-    def test_execute_raises_exception(self):
-        uut = NoInterface("-version-")
-        assert_raises(NoCompatibleRunnerInterface, uut.execute, [])
-
-    def test_exception_contains_version(self):
-        uut = NoInterface("-version-")
-        try:
-            uut.execute()
-        except NoCompatibleRunnerInterface as e:
-            assert_equals(str(e), "No compatible runner interface for version -version-")
 
 @patch("data.runner_interface.Shell")
 class TestRunnerInterface_0_0_8:

--- a/mubench.pipeline/tests/data/test_runner_interface.py
+++ b/mubench.pipeline/tests/data/test_runner_interface.py
@@ -30,9 +30,8 @@ class TestRunnerInterface:
         actual = RunnerInterface.get(RunnerInterfaceTestImpl.TEST_VERSION, "", dict())
         assert_true(isinstance(actual, RunnerInterfaceTestImpl))
 
-    def test_get_interface_version_default_for_unavailable_version(self):
-        actual = RunnerInterface.get("1000.90.42", "", dict())
-        assert_true(isinstance(actual, NoInterface))
+    def test_get_interface_version_raises_for_unavailable_version(self):
+        assert_raises(NoCompatibleRunnerInterface, RunnerInterface.get, "1000.90.42", "", dict())
 
     def test_interface_is_legacy(self):
         class LatestInterface(RunnerInterfaceTestImpl): pass

--- a/mubench.pipeline/tests/data/test_runner_interface.py
+++ b/mubench.pipeline/tests/data/test_runner_interface.py
@@ -31,7 +31,7 @@ class TestRunnerInterface:
         assert_true(isinstance(actual, RunnerInterfaceTestImpl))
 
     def test_get_interface_version_default_for_unavailable_version(self):
-        actual = RunnerInterface.get("-unavailable_version-", "", dict())
+        actual = RunnerInterface.get("1000.90.42", "", dict())
         assert_true(isinstance(actual, NoInterface))
 
     def test_interface_is_legacy(self):

--- a/mubench.pipeline/tests/test_utils/runner_interface_test_impl.py
+++ b/mubench.pipeline/tests/test_utils/runner_interface_test_impl.py
@@ -1,14 +1,15 @@
+from distutils.version import StrictVersion
 from unittest.mock import MagicMock
 
 from data.runner_interface import RunnerInterface
 
 class RunnerInterfaceTestImpl(RunnerInterface):
-    TEST_VERSION = "V_TEST"
+    TEST_VERSION = "0.0.0"
 
     def __init__(self, jar_path, java_options):
         super().__init__(jar_path, java_options)
         self.execute = MagicMock()
 
     @staticmethod
-    def version() -> str:
-        return RunnerInterfaceTestImpl.TEST_VERSION
+    def version() -> StrictVersion:
+        return StrictVersion(RunnerInterfaceTestImpl.TEST_VERSION)

--- a/mubench.pipeline/tests/test_utils/runner_interface_test_impl.py
+++ b/mubench.pipeline/tests/test_utils/runner_interface_test_impl.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 from data.runner_interface import RunnerInterface
 
 class RunnerInterfaceTestImpl(RunnerInterface):
-    TEST_VERSION = "0.0.0"
+    TEST_VERSION = "0.0"
 
     def __init__(self, jar_path, java_options):
         super().__init__(jar_path, java_options)

--- a/mubench.pipeline/tests/test_utils/runner_interface_test_impl.py
+++ b/mubench.pipeline/tests/test_utils/runner_interface_test_impl.py
@@ -13,3 +13,7 @@ class RunnerInterfaceTestImpl(RunnerInterface):
     @staticmethod
     def version() -> StrictVersion:
         return StrictVersion(RunnerInterfaceTestImpl.TEST_VERSION)
+
+    @staticmethod
+    def changelog() -> str:
+        "-changes-"


### PR DESCRIPTION
We still need to discuss where the warning should occur. The problem is once again, that the don't have direct access to logging when creating the interface. Neither does the detector. I'm not really sure how we should approach this. 

The first layer where we use logging again is in `benchmark.py:105`, where we run `find_detector`. 
The next time we have logging in the interface is on execution, but I doubt we want to dump the changelogs on each runner execution. We could instead put the changelogs into files and only log a short warning with some hint to the changelogs.