### PR TITLE
Add checks for system requirements (requires container rebuild)

### DIFF
--- a/mubench.pipeline/requirements.py
+++ b/mubench.pipeline/requirements.py
@@ -1,3 +1,6 @@
+import psutil
+from hurry.filesize import size
+
 from utils.shell import Shell
 
 
@@ -74,3 +77,23 @@ class RequestsRequirement(Requirement):
 
     def check(self):
         pass
+
+class CPUCountRequirement(Requirement):
+    def __init__(self):
+        super().__init__("CPUs >= 2")
+
+    def check(self):
+        cpu_count = psutil.cpu_count(logical=False)
+        if cpu_count < 2:
+            raise ValueError("Only {} CPUs available.".format(cpu_count))
+
+class MemoryRequirement(Requirement):
+    MIN_MEMORY = 8589934592
+
+    def __init__(self):
+        super().__init__("Memory >= {}".format(size(self.MIN_MEMORY)))
+
+    def check(self):
+        memory = psutil.virtual_memory().total
+        if memory < self.MIN_MEMORY:
+            raise ValueError("Only {} of memory available.".format(size(memory)))

--- a/mubench.pipeline/requirements.py
+++ b/mubench.pipeline/requirements.py
@@ -98,6 +98,14 @@ class CPUCountRequirement(Requirement):
             with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as file:
                 quota = int(file.readline())
 
+            """
+                cpu-quota is the guaranteed microseconds of CPU time the container will get.
+                cpu-period is the scheduler period, which defaults to one second in microseconds.
+                The actual access to CPUs can be calculated using 'cpu-quota / cpu-period'.
+                Using '--cpus=X', docker sets the cpu-period to 100000 and cpu-quota to 100000 * X.
+                The default cpu-quota is -1, hence we check the host sytem in that case.
+                Example: '--cpus=1.5' means '--cpu-period=100000 --cpu-quota=150000'.
+            """
             no_limit = quota < 0
             if no_limit:
                 return self._get_normal_cpu_count()

--- a/mubench.pipeline/requirements.py
+++ b/mubench.pipeline/requirements.py
@@ -140,6 +140,7 @@ def _in_container() -> bool:
 
 def _try_import(module):
     try:
+        import importlib
         return importlib.import_module(module)
     except Exception as e:
         raise ImportError("Check requires {}: {}".format(module, e))

--- a/mubench.pipeline/requirements.py
+++ b/mubench.pipeline/requirements.py
@@ -146,12 +146,12 @@ class MemoryRequirement(Requirement):
         except Exception as e:
             raise RuntimeError("Failed to check memory: {}".format(e))
 
-    def _to_readable_size(self, memory: int) -> str:
+    def _to_readable_size(self, size_in_bytes: int) -> str:
         try:
             hf = _try_import("hurry.filesize")
-            return str(hf.size(memory))
+            return str(hf.size(size_in_bytes))
         except ImportError:
-            return str(memory) + "B"
+            return str(size_in_bytes) + "B"
 
 
 def _in_container() -> bool:

--- a/mubench.pipeline/requirements.py
+++ b/mubench.pipeline/requirements.py
@@ -110,7 +110,8 @@ class CPUCountRequirement(Requirement):
             if no_limit:
                 return self._get_normal_cpu_count()
             else:
-                return quota / 100000
+                cpu_period = 100000
+                return quota / cpu_period
 
         except Exception as e:
             raise RuntimeError("Failed to check CPU count: {}".format(e))

--- a/mubench.pipeline/requirements.py
+++ b/mubench.pipeline/requirements.py
@@ -1,4 +1,3 @@
-import psutil
 from hurry.filesize import size
 from os.path import exists
 from utils.shell import Shell
@@ -93,6 +92,7 @@ class CPUCountRequirement(Requirement):
         if _in_container():
             return self._get_container_cpu_count()
         else:
+            import psutil
             return psutil.cpu_count(logical=False)
 
     def _get_container_cpu_count(self):
@@ -118,6 +118,7 @@ class MemoryRequirement(Requirement):
         if _in_container():
             return self._get_container_memory_limit()
         else:
+            import psutil
             return psutil.virtual_memory().total
 
     def _get_container_memory_limit(self):

--- a/mubench.pipeline/requirements.txt
+++ b/mubench.pipeline/requirements.txt
@@ -1,2 +1,4 @@
 PyYaml
 requests
+psutil
+hurry.filesize


### PR DESCRIPTION
Added `psutil` for system information and `hurry.filesize` to pretty print memory size.
I wrote no unit tests, since we would have to mock the essential functionality anyway. Errors should be noticeable on Shippable.

Notes: 
- We exclude logical CPUs.
- Memory is given in bytes. With `hurry.filesize` the current value prints as `8G`.