### PR TITLE
Implement a dataset consistency check

### DIFF
--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -20,7 +20,7 @@ from tasks.implementations.info import Info
 from tasks.implementations.publish_findings_task import PublishFindingsTask
 from tasks.implementations.publish_metadata_task import PublishMetadataTask
 from utils import command_line_util
-from utils.dataset_util import get_datasets, get_available_datasets, get_white_list
+from utils.dataset_util import get_datasets, get_available_dataset_ids, get_white_list
 from utils.logging import IndentFormatter
 
 MUBENCH_ROOT_PATH = join(dirname(abspath(__file__)), os.pardir)
@@ -145,7 +145,7 @@ class Benchmark:
 
 available_detectors = get_available_detector_ids(Benchmark.DETECTORS_PATH)
 available_scripts = stats.get_available_calculator_names()
-available_datasets = get_available_datasets(Benchmark.DATASETS_FILE_PATH)
+available_datasets = get_available_dataset_ids(Benchmark.DATASETS_FILE_PATH)
 config = command_line_util.parse_args(sys.argv, available_detectors, available_scripts, available_datasets)
 
 logger = logging.getLogger()

--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -11,6 +11,7 @@ from data.detectors import find_detector, get_available_detector_ids
 from data.experiments import ProvidedPatternsExperiment, TopFindingsExperiment, BenchmarkExperiment
 from task_runner import TaskRunner
 from tasks.implementations import stats
+from tasks.implementations.dataset_check import DatasetCheck
 from tasks.implementations.requirements_check import RequirementsCheck
 from tasks.implementations.checkout import Checkout
 from tasks.implementations.compile import Compile
@@ -19,7 +20,7 @@ from tasks.implementations.info import Info
 from tasks.implementations.publish_findings_task import PublishFindingsTask
 from tasks.implementations.publish_metadata_task import PublishMetadataTask
 from utils import command_line_util
-from utils.dataset_util import get_available_datasets, get_white_list
+from utils.dataset_util import get_datasets, get_available_datasets, get_white_list
 from utils.logging import IndentFormatter
 
 MUBENCH_ROOT_PATH = join(dirname(abspath(__file__)), os.pardir)
@@ -57,6 +58,11 @@ class Benchmark:
 
     def _setup_check(self):
         self.runner.add(RequirementsCheck())
+
+    def _setup_dataset_check(self):
+        self.runner.add(DatasetCheck(get_datasets(self.DATASETS_FILE_PATH),
+                                     self.CHECKOUTS_PATH,
+                                     self.DATA_PATH))
 
     def _setup_stats(self) -> None:
         stats_calculator = stats.get_calculator(self.config.script)
@@ -132,6 +138,8 @@ class Benchmark:
                 self._setup_publish_metadata()
         elif config.task == 'stats':
             self._setup_stats()
+        elif config.task == 'dataset-check':
+            self._setup_dataset_check()
 
         self.runner.run()
 

--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -20,7 +20,7 @@ from tasks.implementations.info import Info
 from tasks.implementations.publish_findings_task import PublishFindingsTask
 from tasks.implementations.publish_metadata_task import PublishMetadataTask
 from utils import command_line_util
-from utils.dataset_util import get_datasets, get_available_dataset_ids, get_white_list
+from utils.dataset_util import get_available_datasets, get_available_dataset_ids, get_white_list
 from utils.logging import IndentFormatter
 
 MUBENCH_ROOT_PATH = join(dirname(abspath(__file__)), os.pardir)
@@ -60,7 +60,7 @@ class Benchmark:
         self.runner.add(RequirementsCheck())
 
     def _setup_dataset_check(self):
-        self.runner.add(DatasetCheck(get_datasets(self.DATASETS_FILE_PATH),
+        self.runner.add(DatasetCheck(get_available_datasets(self.DATASETS_FILE_PATH),
                                      self.CHECKOUTS_PATH,
                                      self.DATA_PATH))
 

--- a/mubench.pipeline/data/project_version.py
+++ b/mubench.pipeline/data/project_version.py
@@ -82,8 +82,6 @@ class ProjectVersion:
     def misuses(self) -> List[Misuse]:
         if not self._MISUSES:
             misuse_ids = self._yaml.get("misuses", []) or []
-            if not misuse_ids:
-                logging.getLogger("version").warning("!! %s has no misuses!", self)
             self._MISUSES = [Misuse(self._base_path, self.__project.id, misuse_id) for misuse_id in misuse_ids
                              if Misuse.is_misuse(join(self._misuses_dir, misuse_id))]
 

--- a/mubench.pipeline/task_runner.py
+++ b/mubench.pipeline/task_runner.py
@@ -22,9 +22,9 @@ class TaskRunner:
         for task in self.tasks:
             logger = logging.getLogger()
             logger.info("Starting %s %s...", task.name, datetime.now().strftime("at %H:%M:%S"))
-            task.start()
             task.black_list = self.black_list
             task.white_list = self.white_list
+            task.start()
             for project in self._get_projects(self.data_path):
                 logger = logging.getLogger("project")
                 if self.__skip(project):

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -34,7 +34,7 @@ class DatasetCheck(ProjectVersionMisuseTask):
         self.logger = logging.getLogger("datasetcheck.project.version")
         self._register_entry(version.id)
         self._check_required_keys_in_version_yaml(project, version)
-        self._check_misuses_listed_in_version_exist(version)
+        self._check_misuses_listed_in_version_exist(project, version)
         return super().process_project_version(project, version)
 
     def process_project_version_misuse(self, project: Project, version: ProjectVersion, misuse: Misuse):
@@ -134,9 +134,9 @@ class DatasetCheck(ProjectVersionMisuseTask):
                 if "url" not in source:
                     self._report_missing_key("source.url", yaml_path)
 
-    def _check_misuses_listed_in_version_exist(self, version: ProjectVersion):
+    def _check_misuses_listed_in_version_exist(self, project: Project, version: ProjectVersion):
         for misuse_id in version._yaml.get("misuses", []) or []:
-            if misuse_id not in [misuse.misuse_id for misuse in version.misuses]:
+            if not Misuse.is_misuse(join(project.path, project.MISUSES_DIR, misuse_id)):
                 self._report_unknown_misuse(version.id, misuse_id)
 
     def _check_misuse_location_exists(self, project: Project, version: ProjectVersion, misuse: Misuse):

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -2,7 +2,7 @@ import logging
 
 from typing import Dict, List, Optional, Any
 from os import listdir
-from os.path import join, isdir
+from os.path import join, isdir, basename, exists
 
 from data.misuse import Misuse
 from data.project import Project
@@ -153,8 +153,8 @@ class DatasetCheck(ProjectVersionMisuseTask):
                 if not self._location_exists(source_base_path, location.file, location.method):
                     self._cannot_find_location(str(location), "{}/misuses/{}/misuse.yml".format(project.id, misuse.misuse_id))
 
-    def _location_exists(source_base_path, file_, method) -> bool:
-        return get_snippets(source_base_path, location.file, location.method)
+    def _location_exists(self, source_base_path, file_, method) -> bool:
+        return get_snippets(source_base_path, file_, method)
 
     def _new_known_datasets_entry(self, id_: str):
         for dataset, entries in self.datasets.items():
@@ -198,6 +198,9 @@ class DatasetCheck(ProjectVersionMisuseTask):
         project_dirs = [join(data_base_path, subdir) for subdir in listdir(data_base_path) if isdir(join(data_base_path, subdir))]
         for project_dir in project_dirs:
             misuses_dir = join(project_dir, "misuses")
+            if not exists(misuses_dir):
+                continue
+
             misuse_ids = [subdir for subdir in listdir(misuses_dir) if isdir(join(misuses_dir, subdir))]
             misuse_ids = ["{}.{}".format(basename(project_dir), misuse) for misuse in misuse_ids]
             misuses.extend(misuse_ids)

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -14,6 +14,11 @@ class DatasetCheck(ProjectVersionMisuseTask):
         super().__init__()
 
     def process_project(self, project: Project):
+        self._check_required_keys_in_project_yaml(project)
+
+        return super().process_project(project)
+
+    def _check_required_keys_in_project_yaml(self, project: Project):
         yaml_path = "{}/project.yml".format(project.id)
 
         if "name" not in project._YAML:
@@ -27,9 +32,12 @@ class DatasetCheck(ProjectVersionMisuseTask):
             if "url" not in project._YAML["repository"]:
                 self._missing_key("repository.url", yaml_path)
 
-        return super().process_project(project)
-
     def process_project_version(self, project: Project, version: ProjectVersion):
+        self._check_required_keys_in_version_yaml(project, version)
+
+        return super().process_project_version(project, version)
+
+    def _check_required_keys_in_version_yaml(self, project: Project, version: ProjectVersion):
         yaml_path = "{}/versions/{}/version.yml".format(project.id, version.version_id)
 
         if "revision" not in version._YAML:
@@ -49,9 +57,12 @@ class DatasetCheck(ProjectVersionMisuseTask):
         if not version._YAML.get("misuses", None):
             self._missing_key("misuses", yaml_path)
 
-        return super().process_project_version(project, version)
-
     def process_project_version_misuse(self, project: Project, version: ProjectVersion, misuse: Misuse):
+        self._check_required_keys_in_misuse_yaml(project, version, misuse)
+
+        return self.ok()
+
+    def _check_required_keys_in_misuse_yaml(self, project: Project, version: ProjectVersion, misuse: Misuse):
         yaml_path = "{}/misuses/{}/misuse.yml".format(project.id, misuse.misuse_id)
 
         if "location" not in misuse._YAML:
@@ -95,8 +106,6 @@ class DatasetCheck(ProjectVersionMisuseTask):
                 self._missing_key("source.name", yaml_path)
             if "url" not in source:
                 self._missing_key("source.url", yaml_path)
-
-        return self.ok()
 
     def _missing_key(self, tag: str, file_path: str):
         self.logger.warning('Missing "{}" in "{}".'.format(tag, file_path))

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -24,17 +24,20 @@ class DatasetCheck(ProjectVersionMisuseTask):
         self.misuses_not_listed_in_any_version = self._get_all_misuses(self.data_base_path)
 
     def process_project(self, project: Project):
+        self.logger = logging.getLogger("datasetcheck.project")
         self._new_known_datasets_entry(project.id)
         self._check_required_keys_in_project_yaml(project)
         return super().process_project(project)
 
     def process_project_version(self, project: Project, version: ProjectVersion):
+        self.logger = logging.getLogger("datasetcheck.project.version")
         self._new_known_datasets_entry(version.id)
         self._check_required_keys_in_version_yaml(project, version)
         self._check_misuses_listed_in_version_exist(version)
         return super().process_project_version(project, version)
 
     def process_project_version_misuse(self, project: Project, version: ProjectVersion, misuse: Misuse):
+        self.logger = logging.getLogger("datasetcheck.project.version.misuse")
         self._new_known_datasets_entry(misuse.id)
         self._misuse_listed_in_version(misuse.id)
         self._check_required_keys_in_misuse_yaml(project, version, misuse)
@@ -43,8 +46,10 @@ class DatasetCheck(ProjectVersionMisuseTask):
         return self.ok()
 
     def end(self):
-        self._report_unknown_dataset_entries()
+        self.logger = logging.getLogger("datasetcheck.misuse")
         self._report_misuses_not_listed_in_any_version()
+        self.logger = logging.getLogger("datasetcheck")
+        self._report_unknown_dataset_entries()
 
     def _check_required_keys_in_project_yaml(self, project: Project):
         yaml_path = "{}/project.yml".format(project.id)

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -30,6 +30,25 @@ class DatasetCheck(ProjectVersionMisuseTask):
         return super().process_project(project)
 
     def process_project_version(self, project: Project, version: ProjectVersion):
+        yaml_path = "{}/{}/version.yml".format(project.id, version.version_id)
+
+        if "revision" not in version._YAML:
+            self._missing_key("revision", yaml_path)
+
+        if "build" not in version._YAML:
+            self._missing_key("build", yaml_path)
+        else:
+            build = version._YAML["build"]
+            if "classes" not in build:
+                self._missing_key("build.classes", yaml_path)
+            if not build.get("commands", None):
+                self._missing_key("build.commands", yaml_path)
+            if "src" not in build:
+                self._missing_key("build.src", yaml_path)
+
+        if not version._YAML.get("misuses", None):
+            self._missing_key("misuses", yaml_path)
+
         return super().process_project_version(project, version)
 
     def process_project_version_misuse(self, project: Project, version: ProjectVersion, misuse: Misuse):

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -36,6 +36,10 @@ class DatasetCheck(ProjectVersionMisuseTask):
     def process_project_version(self, project: Project, version: ProjectVersion):
         self._check_required_keys_in_version_yaml(project, version)
 
+        for misuse_id in version._yaml.get("misuses", []) or []:
+            if misuse_id not in [misuse.misuse_id for misuse in version.misuses]:
+                self._unknown_misuse(version.id, misuse_id)
+
         return super().process_project_version(project, version)
 
     def _check_required_keys_in_version_yaml(self, project: Project, version: ProjectVersion):
@@ -118,3 +122,6 @@ class DatasetCheck(ProjectVersionMisuseTask):
 
     def _version_misuse_conflict(self, project_id: str, conflicting_id: str):
         self.logger.warning('Conflicting version and misuse "{}" in "{}"'.format(conflicting_id, project_id))
+
+    def _unknown_misuse(self, version_id: str, unknown_misuse_id: str):
+        self.logger.warning('Unknown misuse "{}" in "{}"'.format(unknown_misuse_id, version_id))

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -183,7 +183,7 @@ class DatasetCheck(ProjectVersionMisuseTask):
 
     def _report_misuses_not_listed_in_any_version(self):
         for misuse in self.misuses_not_listed_in_any_version:
-            self._misuse_not_listed(misuse)
+            self._report_misuse_not_listed(misuse)
 
     def _report_missing_key(self, tag: str, file_path: str):
         self.logger.warning('Missing "{}" in "{}".'.format(tag, file_path))

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -20,18 +20,18 @@ class DatasetCheck(ProjectVersionMisuseTask):
 
     def _check_required_keys_in_project_yaml(self, project: Project):
         yaml_path = "{}/project.yml".format(project.id)
+        project_yaml = project._yaml
 
-        if "name" not in project._YAML:
+        if "name" not in project_yaml:
             self._missing_key("name", yaml_path)
 
-        if "repository" not in project._YAML:
+        if "repository" not in project_yaml:
             self._missing_key("repository", yaml_path)
         else:
-            if "type" not in project._YAML["repository"]:
+            if "type" not in project_yaml["repository"]:
                 self._missing_key("repository.type", yaml_path)
-            if "url" not in project._YAML["repository"]:
+            if "url" not in project_yaml["repository"]:
                 self._missing_key("repository.url", yaml_path)
-
 
     def process_project_version(self, project: Project, version: ProjectVersion):
         self._check_required_keys_in_version_yaml(project, version)
@@ -40,14 +40,15 @@ class DatasetCheck(ProjectVersionMisuseTask):
 
     def _check_required_keys_in_version_yaml(self, project: Project, version: ProjectVersion):
         yaml_path = "{}/versions/{}/version.yml".format(project.id, version.version_id)
+        version_yaml = version._yaml
 
-        if "revision" not in version._YAML:
+        if "revision" not in version_yaml:
             self._missing_key("revision", yaml_path)
 
-        if "build" not in version._YAML:
+        if "build" not in version_yaml:
             self._missing_key("build", yaml_path)
         else:
-            build = version._YAML["build"]
+            build = version_yaml["build"]
             if "classes" not in build:
                 self._missing_key("build.classes", yaml_path)
             if not build.get("commands", None):
@@ -55,7 +56,7 @@ class DatasetCheck(ProjectVersionMisuseTask):
             if "src" not in build:
                 self._missing_key("build.src", yaml_path)
 
-        if not version._YAML.get("misuses", None):
+        if not version_yaml.get("misuses", None):
             self._missing_key("misuses", yaml_path)
 
     def process_project_version_misuse(self, project: Project, version: ProjectVersion, misuse: Misuse):
@@ -68,44 +69,45 @@ class DatasetCheck(ProjectVersionMisuseTask):
 
     def _check_required_keys_in_misuse_yaml(self, project: Project, version: ProjectVersion, misuse: Misuse):
         yaml_path = "{}/misuses/{}/misuse.yml".format(project.id, misuse.misuse_id)
+        misuse_yaml = misuse._yaml
 
-        if "location" not in misuse._YAML:
+        if "location" not in misuse_yaml:
             self._missing_key("location", yaml_path)
         else:
-            location = misuse._YAML["location"]
+            location = misuse_yaml["location"]
             if "file" not in location:
                 self._missing_key("location.file", yaml_path)
             if "method" not in location:
                 self._missing_key("location.method", yaml_path)
 
-        if "api" not in misuse._YAML:
+        if "api" not in misuse_yaml:
             self._missing_key("api", yaml_path)
 
-        if not misuse._YAML.get("characteristics", None):
+        if not misuse_yaml.get("characteristics", None):
             self._missing_key("characteristics", yaml_path)
 
-        if not misuse._YAML.get("description", None):
+        if not misuse_yaml.get("description", None):
             self._missing_key("description", yaml_path)
 
-        if "fix" not in misuse._YAML:
+        if "fix" not in misuse_yaml:
             self._missing_key("fix", yaml_path)
         else:
-            fix = misuse._YAML["fix"]
+            fix = misuse_yaml["fix"]
             if "commit" not in fix:
                 self._missing_key("fix.commit", yaml_path)
             if "revision" not in fix:
                 self._missing_key("fix.revision", yaml_path)
 
-        if "internal" not in misuse._YAML:
+        if "internal" not in misuse_yaml:
             self._missing_key("internal", yaml_path)
 
-        if "report" not in misuse._YAML:
+        if "report" not in misuse_yaml:
             self._missing_key("report", yaml_path)
 
-        if "source" not in misuse._YAML:
+        if "source" not in misuse_yaml:
             self._missing_key("source", yaml_path)
         else:
-            source = misuse._YAML["source"]
+            source = misuse_yaml["source"]
             if "name" not in source:
                 self._missing_key("source.name", yaml_path)
             if "url" not in source:

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -186,16 +186,16 @@ class DatasetCheck(ProjectVersionMisuseTask):
         self.logger.warning('ID "{}" is used for multiple data entries.'.format(conflicting_id))
 
     def _report_unknown_misuse(self, version_id: str, unknown_misuse_id: str):
-        self.logger.warning('Unknown misuse "{}" in "{}"'.format(unknown_misuse_id, version_id))
+        self.logger.warning('Unknown misuse "{}" in "{}".'.format(unknown_misuse_id, version_id))
 
     def _report_cannot_find_location(self, location: str, misuse_yaml_path: str):
-        self.logger.warning('Cannot find "{}" listed in "{}"'.format(location, misuse_yaml_path))
+        self.logger.warning('Cannot find "{}" listed in "{}".'.format(location, misuse_yaml_path))
 
     def _report_unknown_dataset_entry(self, dataset: str, entry: str):
-        self.logger.warning('Unknown dataset entry "{}" in dataset "{}"'.format(entry, dataset))
+        self.logger.warning('Unknown dataset entry "{}" in dataset "{}".'.format(entry, dataset))
 
     def _report_misuse_not_listed(self, misuse_id: str):
-        self.logger.warning('Misuse "{}" is not listed in any versions'.format(misuse_id))
+        self.logger.warning('Misuse "{}" is not listed in any versions.'.format(misuse_id))
 
     def _get_all_misuses(self, data_base_path: str) -> List[str]:
         misuses = []

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -154,7 +154,12 @@ class DatasetCheck(ProjectVersionMisuseTask):
                         self._report_cannot_find_location(str(location), "{}/misuses/{}/misuse.yml".format(project.id, misuse.misuse_id))
 
     def _location_exists(self, source_base_path, file_, method) -> bool:
-        return get_snippets(source_base_path, file_, method)
+        try:
+            snippets = get_snippets(source_base_path, file_, method)
+        except:
+            return False
+        else:
+            return len(snippets) > 0
 
     def _register_entry(self, project: Project, id_: str):
         for dataset, entries in self.datasets.items():

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -1,0 +1,39 @@
+import logging
+
+from typing import Dict, Optional, Any
+
+from data.misuse import Misuse
+from data.project import Project
+from data.project_version import ProjectVersion
+from tasks.project_version_misuse_task import ProjectVersionMisuseTask
+
+
+class DatasetCheck(ProjectVersionMisuseTask):
+    def __init__(self):
+        self.logger = logging.getLogger("datasetcheck")
+        super().__init__()
+
+    def process_project(self, project: Project):
+        yaml_path = "{}/project.yml".format(project.id)
+
+        if "name" not in project._YAML:
+            self._missing_key("name", yaml_path)
+
+        if "repository" not in project._YAML:
+            self._missing_key("repository", yaml_path)
+        else:
+            if "type" not in project._YAML["repository"]:
+                self._missing_key("repository.type", yaml_path)
+            if "url" not in project._YAML["repository"]:
+                self._missing_key("repository.url", yaml_path)
+
+        return super().process_project(project)
+
+    def process_project_version(self, project: Project, version: ProjectVersion):
+        return super().process_project_version(project, version)
+
+    def process_project_version_misuse(self, project: Project, version: ProjectVersion, misuse: Misuse):
+        return self.ok()
+
+    def _missing_key(self, tag: str, file_path: str):
+        self.logger.warning('Missing "{}" in "{}".'.format(tag, file_path))

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -30,7 +30,7 @@ class DatasetCheck(ProjectVersionMisuseTask):
         return super().process_project(project)
 
     def process_project_version(self, project: Project, version: ProjectVersion):
-        yaml_path = "{}/{}/version.yml".format(project.id, version.version_id)
+        yaml_path = "{}/versions/{}/version.yml".format(project.id, version.version_id)
 
         if "revision" not in version._YAML:
             self._missing_key("revision", yaml_path)
@@ -52,6 +52,50 @@ class DatasetCheck(ProjectVersionMisuseTask):
         return super().process_project_version(project, version)
 
     def process_project_version_misuse(self, project: Project, version: ProjectVersion, misuse: Misuse):
+        yaml_path = "{}/misuses/{}/misuse.yml".format(project.id, misuse.misuse_id)
+
+        if "location" not in misuse._YAML:
+            self._missing_key("location", yaml_path)
+        else:
+            location = misuse._YAML["location"]
+            if "file" not in location:
+                self._missing_key("location.file", yaml_path)
+            if "method" not in location:
+                self._missing_key("location.method", yaml_path)
+
+        if "api" not in misuse._YAML:
+            self._missing_key("api", yaml_path)
+
+        if not misuse._YAML.get("characteristics", None):
+            self._missing_key("characteristics", yaml_path)
+
+        if not misuse._YAML.get("description", None):
+            self._missing_key("description", yaml_path)
+
+        if "fix" not in misuse._YAML:
+            self._missing_key("fix", yaml_path)
+        else:
+            fix = misuse._YAML["fix"]
+            if "commit" not in fix:
+                self._missing_key("fix.commit", yaml_path)
+            if "revision" not in fix:
+                self._missing_key("fix.revision", yaml_path)
+
+        if "internal" not in misuse._YAML:
+            self._missing_key("internal", yaml_path)
+
+        if "report" not in misuse._YAML:
+            self._missing_key("report", yaml_path)
+
+        if "source" not in misuse._YAML:
+            self._missing_key("source", yaml_path)
+        else:
+            source = misuse._YAML["source"]
+            if "name" not in source:
+                self._missing_key("source.name", yaml_path)
+            if "url" not in source:
+                self._missing_key("source.url", yaml_path)
+
         return self.ok()
 
     def _missing_key(self, tag: str, file_path: str):

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -63,14 +63,14 @@ class DatasetCheck(ProjectVersionMisuseTask):
         else:
             if "type" not in project_yaml["repository"]:
                 self._missing_key("repository.type", yaml_path)
-            if "url" not in project_yaml["repository"]:
+            if "url" not in project_yaml["repository"] and not _is_synthetic(project):
                 self._missing_key("repository.url", yaml_path)
 
     def _check_required_keys_in_version_yaml(self, project: Project, version: ProjectVersion):
         yaml_path = "{}/versions/{}/version.yml".format(project.id, version.version_id)
         version_yaml = version._yaml
 
-        if "revision" not in version_yaml:
+        if "revision" not in version_yaml and not _is_synthetic(project):
             self._missing_key("revision", yaml_path)
 
         if "build" not in version_yaml:
@@ -109,29 +109,30 @@ class DatasetCheck(ProjectVersionMisuseTask):
         if not misuse_yaml.get("description", None):
             self._missing_key("description", yaml_path)
 
-        if "fix" not in misuse_yaml:
-            self._missing_key("fix", yaml_path)
-        else:
-            fix = misuse_yaml["fix"]
-            if "commit" not in fix:
-                self._missing_key("fix.commit", yaml_path)
-            if "revision" not in fix:
-                self._missing_key("fix.revision", yaml_path)
+        if not _is_synthetic(project):
+            if "fix" not in misuse_yaml:
+                self._missing_key("fix", yaml_path)
+            else:
+                fix = misuse_yaml["fix"]
+                if "commit" not in fix:
+                    self._missing_key("fix.commit", yaml_path)
+                if "revision" not in fix:
+                    self._missing_key("fix.revision", yaml_path)
 
-        if "internal" not in misuse_yaml:
-            self._missing_key("internal", yaml_path)
+            if "internal" not in misuse_yaml:
+                self._missing_key("internal", yaml_path)
 
-        if "report" not in misuse_yaml:
-            self._missing_key("report", yaml_path)
+            if "report" not in misuse_yaml:
+                self._missing_key("report", yaml_path)
 
-        if "source" not in misuse_yaml:
-            self._missing_key("source", yaml_path)
-        else:
-            source = misuse_yaml["source"]
-            if "name" not in source:
-                self._missing_key("source.name", yaml_path)
-            if "url" not in source:
-                self._missing_key("source.url", yaml_path)
+            if "source" not in misuse_yaml:
+                self._missing_key("source", yaml_path)
+            else:
+                source = misuse_yaml["source"]
+                if "name" not in source:
+                    self._missing_key("source.name", yaml_path)
+                if "url" not in source:
+                    self._missing_key("source.url", yaml_path)
 
     def _check_misuses_listed_in_version_exist(self, version: ProjectVersion):
         for misuse_id in version._yaml.get("misuses", []) or []:
@@ -211,3 +212,7 @@ class DatasetCheck(ProjectVersionMisuseTask):
             misuses.extend(misuse_ids)
 
         return misuses
+
+
+def _is_synthetic(project: Project) -> bool:
+    return project._yaml.get("repository", {}).get("type", '') == "synthetic"

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -22,6 +22,9 @@ class DatasetCheck(ProjectVersionMisuseTask):
         self.registered_entries = set()
 
     def start(self):
+        if self.white_list or self.black_list:
+            self.logger.warning("Using filter option(s). You may encounter invalid warnings!")
+
         self.misuses_not_listed_in_any_version = self._get_all_misuses(self.data_base_path)
 
     def process_project(self, project: Project):

--- a/mubench.pipeline/tasks/implementations/dataset_check.py
+++ b/mubench.pipeline/tasks/implementations/dataset_check.py
@@ -32,6 +32,7 @@ class DatasetCheck(ProjectVersionMisuseTask):
             if "url" not in project._YAML["repository"]:
                 self._missing_key("repository.url", yaml_path)
 
+
     def process_project_version(self, project: Project, version: ProjectVersion):
         self._check_required_keys_in_version_yaml(project, version)
 
@@ -59,6 +60,9 @@ class DatasetCheck(ProjectVersionMisuseTask):
 
     def process_project_version_misuse(self, project: Project, version: ProjectVersion, misuse: Misuse):
         self._check_required_keys_in_misuse_yaml(project, version, misuse)
+
+        if version.version_id == misuse.misuse_id:
+            self._version_misuse_conflict(project.id, version.version_id)
 
         return self.ok()
 
@@ -109,3 +113,6 @@ class DatasetCheck(ProjectVersionMisuseTask):
 
     def _missing_key(self, tag: str, file_path: str):
         self.logger.warning('Missing "{}" in "{}".'.format(tag, file_path))
+
+    def _version_misuse_conflict(self, project_id: str, conflicting_id: str):
+        self.logger.warning('Conflicting version and misuse "{}" in "{}"'.format(conflicting_id, project_id))

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -161,10 +161,9 @@ class TestDatasetCheckMisuse:
         self.uut._check_misuse_location_exists = MagicMock()
 
     def test_missing_location(self):
-        meta = EMPTY_META
         project = create_project("-project-", meta=EMPTY_META)
-        misuse = create_misuse("-id-", project=project)
-        misuse._YAML = meta
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
+        misuse._YAML = EMPTY_META # needs to be set here, since create_misuse adds a location
         version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
@@ -192,9 +191,8 @@ class TestDatasetCheckMisuse:
         self.uut._missing_key.assert_any_call("location.method", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_api(self):
-        meta = {"empty": {}}
         project = create_project("-project-", meta=EMPTY_META)
-        misuse = create_misuse("-id-", project=project, meta=meta)
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
         version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
@@ -202,9 +200,8 @@ class TestDatasetCheckMisuse:
         self.uut._missing_key.assert_any_call("api", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_characteristics(self):
-        meta = EMPTY_META
         project = create_project("-project-", meta=EMPTY_META)
-        misuse = create_misuse("-id-", project=project, meta=meta)
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
         version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
@@ -222,9 +219,8 @@ class TestDatasetCheckMisuse:
         self.uut._missing_key.assert_any_call("characteristics", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_description(self):
-        meta = EMPTY_META
         project = create_project("-project-", meta=EMPTY_META)
-        misuse = create_misuse("-id-", project=project, meta=meta)
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
         version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
@@ -242,9 +238,8 @@ class TestDatasetCheckMisuse:
         self.uut._missing_key.assert_any_call("description", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_fix(self):
-        meta = EMPTY_META
         project = create_project("-project-", meta=EMPTY_META)
-        misuse = create_misuse("-id-", project=project, meta=meta)
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
         version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
@@ -272,9 +267,8 @@ class TestDatasetCheckMisuse:
         self.uut._missing_key.assert_any_call("fix.revision", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_internal(self):
-        meta = EMPTY_META
         project = create_project("-project-", meta=EMPTY_META)
-        misuse = create_misuse("-id-", project=project, meta=meta)
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
         version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
@@ -282,9 +276,8 @@ class TestDatasetCheckMisuse:
         self.uut._missing_key.assert_any_call("internal", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_report(self):
-        meta = EMPTY_META
         project = create_project("-project-", meta=EMPTY_META)
-        misuse = create_misuse("-id-", project=project, meta=meta)
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
         version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
@@ -292,9 +285,8 @@ class TestDatasetCheckMisuse:
         self.uut._missing_key.assert_any_call("report", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_source(self):
-        meta = EMPTY_META
         project = create_project("-project-", meta=EMPTY_META)
-        misuse = create_misuse("-id-", project=project, meta=meta)
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
         version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -8,7 +8,7 @@ EMPTY_META = {"empty": None}
 
 class TestDatasetCheckProject:
     def setup(self):
-        self.uut = DatasetCheck({}, '')
+        self.uut = DatasetCheck({}, '', '')
         self.uut._missing_key = MagicMock()
         self.uut._check_misuse_location_exists = MagicMock()
 
@@ -57,7 +57,7 @@ class TestDatasetCheckProject:
 
 class TestDatasetCheckProjectVersion:
     def setup(self):
-        self.uut = DatasetCheck({}, '')
+        self.uut = DatasetCheck({}, '', '')
         self.uut._missing_key = MagicMock()
         self.uut._check_misuse_location_exists = MagicMock()
 
@@ -156,7 +156,7 @@ class TestDatasetCheckProjectVersion:
 
 class TestDatasetCheckMisuse:
     def setup(self):
-        self.uut = DatasetCheck({}, '')
+        self.uut = DatasetCheck({}, '', '')
         self.uut._missing_key = MagicMock()
         self.uut._check_misuse_location_exists = MagicMock()
 
@@ -316,7 +316,7 @@ class TestDatasetCheckMisuse:
 
 class TestDatasetCheckDatasetLists:
     def setup(self):
-        self.uut = DatasetCheck({}, '')
+        self.uut = DatasetCheck({}, '', '')
         self.uut._unknown_dataset_entry = MagicMock()
         self.uut._check_misuse_location_exists = MagicMock()
 
@@ -360,7 +360,7 @@ class TestDatasetCheckDatasetLists:
 
 class TestDatasetCheckUnknownLocation:
     def setup(self):
-        self.uut = DatasetCheck({}, '')
+        self.uut = DatasetCheck({}, '', '')
         self.uut._cannot_find_location = MagicMock()
 
         self.project = create_project("-project-", meta=EMPTY_META)
@@ -390,3 +390,30 @@ class TestDatasetCheckUnknownLocation:
 
         self.uut._location_exists.assert_called_once_with("-checkout_dir-/-source_dir-", "-file-", "-method-")
         self.uut._cannot_find_location.assert_not_called()
+
+
+class TestDatasetCheckUnlistedMisuses:
+    def setup(self):
+        self.uut = DatasetCheck({}, '', '')
+        self.uut._check_misuse_location_exists = MagicMock()
+        self.uut._misuse_not_listed = MagicMock()
+
+    def test_misuse_not_listed_in_any_version(self):
+        self.uut._get_all_misuses = MagicMock(return_value=["-project-.-misuse-"])
+
+        self.uut.start()
+        self.uut.end()
+
+        self.uut._misuse_not_listed.assert_called_once_with("-project-.-misuse-")
+
+    def test_listed_misuse_is_not_reported(self):
+        self.uut._get_all_misuses = MagicMock(return_value=["-project-.-misuse-"])
+        project = create_project("-project-", meta=EMPTY_META)
+        misuse = create_misuse("-misuse-", project=project, meta=EMPTY_META)
+        version = create_version("-version-", project=project, misuses=[misuse], meta=EMPTY_META)
+
+        self.uut.start()
+        self.uut.process_project_version_misuse(project, version, misuse)
+        self.uut.end()
+
+        self.uut._misuse_not_listed.assert_not_called()

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -54,7 +54,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("revision", "-project-/-id-/version.yml")
+        self.uut._missing_key.assert_any_call("revision", "-project-/versions/-id-/version.yml")
 
     def test_missing_misuses(self):
         meta = {"revision": "1"}
@@ -63,16 +63,16 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("misuses", "-project-/-id-/version.yml")
+        self.uut._missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
 
-    def test_missing_misuses(self):
+    def test_empty_misuses(self):
         meta = {"misuses": []}
         project = create_project("-project-", meta={"empty": ''})
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("misuses", "-project-/-id-/version.yml")
+        self.uut._missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
 
     def test_missing_build(self):
         meta = {"misuses": ["1"]}
@@ -81,7 +81,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build", "-project-/-id-/version.yml")
+        self.uut._missing_key.assert_any_call("build", "-project-/versions/-id-/version.yml")
 
     def test_missing_build_classes(self):
         meta = {"build": {}}
@@ -90,7 +90,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build.classes", "-project-/-id-/version.yml")
+        self.uut._missing_key.assert_any_call("build.classes", "-project-/versions/-id-/version.yml")
 
     def test_missing_build_commands(self):
         meta = {"build": {}}
@@ -99,7 +99,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build.commands", "-project-/-id-/version.yml")
+        self.uut._missing_key.assert_any_call("build.commands", "-project-/versions/-id-/version.yml")
 
     def test_empty_build_commands(self):
         meta = {"build": {"commands": []}}
@@ -108,7 +108,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build.commands", "-project-/-id-/version.yml")
+        self.uut._missing_key.assert_any_call("build.commands", "-project-/versions/-id-/version.yml")
 
 
     def test_missing_build_src(self):
@@ -118,4 +118,170 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build.src", "-project-/-id-/version.yml")
+        self.uut._missing_key.assert_any_call("build.src", "-project-/versions/-id-/version.yml")
+
+class TestDatasetCheckMisuse:
+    def setup(self):
+        self.uut = DatasetCheck()
+        self.uut._missing_key = MagicMock()
+
+    def test_missing_location(self):
+        meta = {"empty": ''}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project)
+        misuse._YAML = meta
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("location", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_location_file(self):
+        meta = {"location": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("location.file", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_location_method(self):
+        meta = {"location": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("location.method", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_api(self):
+        meta = {"empty": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("api", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_characteristics(self):
+        meta = {"empty": ''}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("characteristics", "-project-/misuses/-id-/misuse.yml")
+
+    def test_empty_characteristics(self):
+        meta = {"characteristics": []}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("characteristics", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_description(self):
+        meta = {"empty": ''}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("description", "-project-/misuses/-id-/misuse.yml")
+
+    def test_empty_description(self):
+        meta = {"description": ''}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("description", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_fix(self):
+        meta = {"empty": ''}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("fix", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_fix_commit(self):
+        meta = {"fix": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("fix.commit", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_fix_revision(self):
+        meta = {"fix": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("fix.revision", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_internal(self):
+        meta = {"empty": ''}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("internal", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_report(self):
+        meta = {"empty": ''}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("report", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_source(self):
+        meta = {"empty": ''}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("source", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_source_name(self):
+        meta = {"source": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("source.name", "-project-/misuses/-id-/misuse.yml")
+
+    def test_missing_source_url(self):
+        meta = {"source": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        misuse = create_misuse("-id-", project=project, meta=meta)
+        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        self.uut._missing_key.assert_any_call("source.url", "-project-/misuses/-id-/misuse.yml")

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -42,6 +42,17 @@ class TestDatasetCheckProject:
 
         self.uut._missing_key.assert_any_call("repository.url", "-id-/project.yml")
 
+    def test_version_and_misuse_with_same_name(self):
+        self.uut._version_misuse_conflict = MagicMock()
+        project = create_project("-project-")
+        misuse = create_misuse("-conflict-", project=project)
+        version = create_version("-conflict-", project=project, misuses=[misuse])
+
+        self.uut.process_project(project)
+
+        self.uut._version_misuse_conflict.assert_any_call("-project-", "-conflict-")
+
+
 class TestDatasetCheckProjectVersion:
     def setup(self):
         self.uut = DatasetCheck()

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch, MagicMock, ANY
+from unittest.mock import call, patch, MagicMock, ANY
 from nose.tools import assert_equals
 
 from tasks.implementations.dataset_check import DatasetCheck
@@ -54,6 +54,14 @@ class TestDatasetCheckProject:
 
         self.uut._version_misuse_conflict.assert_any_call("-project-", "-conflict-")
 
+    def test_synthetic_no_url(self):
+        meta = {"name": "-project-name-", "repository": {"type": "synthetic"}}
+        project = create_project("-id-", meta=meta)
+
+        self.uut.process_project(project)
+
+        self.uut._missing_key.assert_not_called()
+
 
 class TestDatasetCheckProjectVersion:
     def setup(self):
@@ -69,6 +77,16 @@ class TestDatasetCheckProjectVersion:
         self.uut.process_project_version(project, version)
 
         self.uut._missing_key.assert_any_call("revision", "-project-/versions/-id-/version.yml")
+
+    def test_synthetic_no_revision(self):
+        meta = {"misuses": ["1"]}
+        project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        assert call("revision", "-project-/versions/-id-/version.yml") \
+               not in self.uut._missing_key.call_args_list
 
     def test_missing_misuses(self):
         meta = {"revision": "1"}
@@ -145,7 +163,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_non_existent_misuse(self):
         self.uut._unknown_misuse = MagicMock()
-        project = create_project("-project-")
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta={"misuses": ["-misuse-"]}, project=project)
         version._MISUSES = []
 
@@ -266,6 +284,16 @@ class TestDatasetCheckMisuse:
 
         self.uut._missing_key.assert_any_call("fix.revision", "-project-/misuses/-id-/misuse.yml")
 
+    def test_synthetic_no_fix(self):
+        project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        assert call("fix", "-project-/misuses/-id-/misuse.yml") \
+               not in self.uut._missing_key.call_args_list
+
     def test_missing_internal(self):
         project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
@@ -275,6 +303,16 @@ class TestDatasetCheckMisuse:
 
         self.uut._missing_key.assert_any_call("internal", "-project-/misuses/-id-/misuse.yml")
 
+    def test_synthetic_no_internal(self):
+        project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        assert call("internal", "-project-/misuses/-id-/misuse.yml") \
+               not in self.uut._missing_key.call_args_list
+
     def test_missing_report(self):
         project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
@@ -283,6 +321,16 @@ class TestDatasetCheckMisuse:
         self.uut.process_project_version_misuse(project, version, misuse)
 
         self.uut._missing_key.assert_any_call("report", "-project-/misuses/-id-/misuse.yml")
+
+    def test_synthetic_no_report(self):
+        project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        assert call("report", "-project-/misuses/-id-/misuse.yml") \
+               not in self.uut._missing_key.call_args_list
 
     def test_missing_source(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -312,6 +360,16 @@ class TestDatasetCheckMisuse:
         self.uut.process_project_version_misuse(project, version, misuse)
 
         self.uut._missing_key.assert_any_call("source.url", "-project-/misuses/-id-/misuse.yml")
+
+    def test_synthetic_no_source(self):
+        project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
+        misuse = create_misuse("-id-", project=project, meta=EMPTY_META)
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
+
+        self.uut.process_project_version_misuse(project, version, misuse)
+
+        assert call("source", "-project-/misuses/-id-/misuse.yml") \
+               not in self.uut._missing_key.call_args_list
 
 
 class TestDatasetCheckDatasetLists:

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -45,14 +45,25 @@ class TestDatasetCheckProject:
         self.uut._report_missing_key.assert_any_call("repository.url", "-id-/project.yml")
 
     def test_version_and_misuse_with_same_name(self):
-        self.uut._report_version_misuse_conflict = MagicMock()
+        self.uut._report_id_conflict = MagicMock()
         project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-conflict-", project=project, meta=EMPTY_META)
         version = create_version("-conflict-", project=project, misuses=[misuse], meta=EMPTY_META)
 
         self.uut.process_project(project)
 
-        self.uut._report_version_misuse_conflict.assert_any_call("-project-", "-conflict-")
+        self.uut._report_id_conflict.assert_any_call("-project-.-conflict-")
+
+    def test_version_and_misuse_from_different_version_with_same_name(self):
+        self.uut._report_id_conflict = MagicMock()
+        project = create_project("-project-", meta=EMPTY_META)
+        misuse_with_conflict = create_misuse("-conflict-", project=project, meta=EMPTY_META)
+        version = create_version("-version-", project=project, misuses=[misuse_with_conflict], meta=EMPTY_META)
+        version_with_conflict = create_version("-conflict-", project=project, misuses=[], meta=EMPTY_META)
+
+        self.uut.process_project(project)
+
+        self.uut._report_id_conflict.assert_any_call("-project-.-conflict-")
 
     def test_synthetic_no_url(self):
         meta = {"name": "-project-name-", "repository": {"type": "synthetic"}}

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -9,7 +9,7 @@ EMPTY_META = {"empty": None}
 class TestDatasetCheckProject:
     def setup(self):
         self.uut = DatasetCheck({}, '', '')
-        self.uut._missing_key = MagicMock()
+        self.uut._report_missing_key = MagicMock()
         self.uut._check_misuse_location_exists = MagicMock()
 
     def test_missing_name(self):
@@ -18,7 +18,7 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_any_call("name", "-id-/project.yml")
+        self.uut._report_missing_key.assert_any_call("name", "-id-/project.yml")
 
     def test_missing_repository(self):
         meta = {"name": "-project-name-"}
@@ -26,7 +26,7 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_any_call("repository", "-id-/project.yml")
+        self.uut._report_missing_key.assert_any_call("repository", "-id-/project.yml")
 
     def test_missing_repository_type(self):
         meta = {"name": "-project-name-", "repository": {"url": "https://github.com/stg-tud/MUBench.git"}}
@@ -34,7 +34,7 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_any_call("repository.type", "-id-/project.yml")
+        self.uut._report_missing_key.assert_any_call("repository.type", "-id-/project.yml")
 
     def test_missing_repository_url(self):
         meta = {"name": "-project-name-", "repository": {"type": "git"}}
@@ -42,17 +42,17 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_any_call("repository.url", "-id-/project.yml")
+        self.uut._report_missing_key.assert_any_call("repository.url", "-id-/project.yml")
 
     def test_version_and_misuse_with_same_name(self):
-        self.uut._version_misuse_conflict = MagicMock()
+        self.uut._report_version_misuse_conflict = MagicMock()
         project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-conflict-", project=project, meta=EMPTY_META)
         version = create_version("-conflict-", project=project, misuses=[misuse], meta=EMPTY_META)
 
         self.uut.process_project(project)
 
-        self.uut._version_misuse_conflict.assert_any_call("-project-", "-conflict-")
+        self.uut._report_version_misuse_conflict.assert_any_call("-project-", "-conflict-")
 
     def test_synthetic_no_url(self):
         meta = {"name": "-project-name-", "repository": {"type": "synthetic"}}
@@ -60,13 +60,13 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_not_called()
+        self.uut._report_missing_key.assert_not_called()
 
 
 class TestDatasetCheckProjectVersion:
     def setup(self):
         self.uut = DatasetCheck({}, '', '')
-        self.uut._missing_key = MagicMock()
+        self.uut._report_missing_key = MagicMock()
         self.uut._check_misuse_location_exists = MagicMock()
 
     def test_missing_revision(self):
@@ -76,7 +76,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("revision", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("revision", "-project-/versions/-id-/version.yml")
 
     def test_synthetic_no_revision(self):
         meta = {"misuses": ["1"]}
@@ -86,7 +86,7 @@ class TestDatasetCheckProjectVersion:
         self.uut.process_project_version(project, version)
 
         assert call("revision", "-project-/versions/-id-/version.yml") \
-               not in self.uut._missing_key.call_args_list
+               not in self.uut._report_missing_key.call_args_list
 
     def test_missing_misuses(self):
         meta = {"revision": "1"}
@@ -95,7 +95,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
 
     def test_empty_misuses(self):
         meta = {"misuses": []}
@@ -104,7 +104,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
 
     def test_misuses_none(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -112,7 +112,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
 
     def test_missing_build(self):
         meta = {"misuses": ["1"]}
@@ -121,7 +121,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("build", "-project-/versions/-id-/version.yml")
 
     def test_missing_build_classes(self):
         meta = {"build": {}}
@@ -130,7 +130,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build.classes", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("build.classes", "-project-/versions/-id-/version.yml")
 
     def test_missing_build_commands(self):
         meta = {"build": {}}
@@ -139,7 +139,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build.commands", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("build.commands", "-project-/versions/-id-/version.yml")
 
     def test_empty_build_commands(self):
         meta = {"build": {"commands": []}}
@@ -148,7 +148,7 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build.commands", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("build.commands", "-project-/versions/-id-/version.yml")
 
 
     def test_missing_build_src(self):
@@ -158,24 +158,24 @@ class TestDatasetCheckProjectVersion:
 
         self.uut.process_project_version(project, version)
 
-        self.uut._missing_key.assert_any_call("build.src", "-project-/versions/-id-/version.yml")
+        self.uut._report_missing_key.assert_any_call("build.src", "-project-/versions/-id-/version.yml")
 
 
     def test_non_existent_misuse(self):
-        self.uut._unknown_misuse = MagicMock()
+        self.uut._report_unknown_misuse = MagicMock()
         project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta={"misuses": ["-misuse-"]}, project=project)
         version._MISUSES = []
 
         self.uut.process_project_version(project, version)
 
-        self.uut._unknown_misuse.assert_any_call(version.id, "-misuse-")
+        self.uut._report_unknown_misuse.assert_any_call(version.id, "-misuse-")
 
 
 class TestDatasetCheckMisuse:
     def setup(self):
         self.uut = DatasetCheck({}, '', '')
-        self.uut._missing_key = MagicMock()
+        self.uut._report_missing_key = MagicMock()
         self.uut._check_misuse_location_exists = MagicMock()
 
     def test_missing_location(self):
@@ -186,7 +186,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("location", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("location", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_location_file(self):
         meta = {"location": {}}
@@ -196,7 +196,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("location.file", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("location.file", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_location_method(self):
         meta = {"location": {}}
@@ -206,7 +206,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("location.method", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("location.method", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_api(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -215,7 +215,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("api", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("api", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_characteristics(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -224,7 +224,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("characteristics", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("characteristics", "-project-/misuses/-id-/misuse.yml")
 
     def test_empty_characteristics(self):
         meta = {"characteristics": []}
@@ -234,7 +234,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("characteristics", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("characteristics", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_description(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -243,7 +243,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("description", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("description", "-project-/misuses/-id-/misuse.yml")
 
     def test_empty_description(self):
         meta = {"description": ''}
@@ -253,7 +253,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("description", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("description", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_fix(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -262,7 +262,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("fix", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("fix", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_fix_commit(self):
         meta = {"fix": {}}
@@ -272,7 +272,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("fix.commit", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("fix.commit", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_fix_revision(self):
         meta = {"fix": {}}
@@ -282,7 +282,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("fix.revision", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("fix.revision", "-project-/misuses/-id-/misuse.yml")
 
     def test_synthetic_no_fix(self):
         project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
@@ -292,7 +292,7 @@ class TestDatasetCheckMisuse:
         self.uut.process_project_version_misuse(project, version, misuse)
 
         assert call("fix", "-project-/misuses/-id-/misuse.yml") \
-               not in self.uut._missing_key.call_args_list
+               not in self.uut._report_missing_key.call_args_list
 
     def test_missing_internal(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -301,7 +301,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("internal", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("internal", "-project-/misuses/-id-/misuse.yml")
 
     def test_synthetic_no_internal(self):
         project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
@@ -311,7 +311,7 @@ class TestDatasetCheckMisuse:
         self.uut.process_project_version_misuse(project, version, misuse)
 
         assert call("internal", "-project-/misuses/-id-/misuse.yml") \
-               not in self.uut._missing_key.call_args_list
+               not in self.uut._report_missing_key.call_args_list
 
     def test_missing_report(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -320,7 +320,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("report", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("report", "-project-/misuses/-id-/misuse.yml")
 
     def test_synthetic_no_report(self):
         project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
@@ -330,7 +330,7 @@ class TestDatasetCheckMisuse:
         self.uut.process_project_version_misuse(project, version, misuse)
 
         assert call("report", "-project-/misuses/-id-/misuse.yml") \
-               not in self.uut._missing_key.call_args_list
+               not in self.uut._report_missing_key.call_args_list
 
     def test_missing_source(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -339,7 +339,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("source", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("source", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_source_name(self):
         meta = {"source": {}}
@@ -349,7 +349,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("source.name", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("source.name", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_source_url(self):
         meta = {"source": {}}
@@ -359,7 +359,7 @@ class TestDatasetCheckMisuse:
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
-        self.uut._missing_key.assert_any_call("source.url", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_missing_key.assert_any_call("source.url", "-project-/misuses/-id-/misuse.yml")
 
     def test_synthetic_no_source(self):
         project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
@@ -369,13 +369,13 @@ class TestDatasetCheckMisuse:
         self.uut.process_project_version_misuse(project, version, misuse)
 
         assert call("source", "-project-/misuses/-id-/misuse.yml") \
-               not in self.uut._missing_key.call_args_list
+               not in self.uut._report_missing_key.call_args_list
 
 
 class TestDatasetCheckDatasetLists:
     def setup(self):
         self.uut = DatasetCheck({}, '', '')
-        self.uut._unknown_dataset_entry = MagicMock()
+        self.uut._report_unknown_dataset_entry = MagicMock()
         self.uut._check_misuse_location_exists = MagicMock()
 
     def test_unknown_entry(self):
@@ -383,7 +383,7 @@ class TestDatasetCheckDatasetLists:
 
         self.uut.end()
 
-        self.uut._unknown_dataset_entry.assert_any_call("-dataset-", "-unknown-entry-")
+        self.uut._report_unknown_dataset_entry.assert_any_call("-dataset-", "-unknown-entry-")
 
     def test_no_warning_on_known_project(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -392,7 +392,7 @@ class TestDatasetCheckDatasetLists:
         self.uut.process_project(project)
         self.uut.end()
 
-        self.uut._unknown_dataset_entry.assert_not_called()
+        self.uut._report_unknown_dataset_entry.assert_not_called()
 
     def test_no_warning_on_known_version(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -402,7 +402,7 @@ class TestDatasetCheckDatasetLists:
         self.uut.process_project_version(project, version)
         self.uut.end()
 
-        self.uut._unknown_dataset_entry.assert_not_called()
+        self.uut._report_unknown_dataset_entry.assert_not_called()
 
     def test_no_warning_on_known_misuse(self):
         project = create_project("-project-", meta=EMPTY_META)
@@ -413,13 +413,13 @@ class TestDatasetCheckDatasetLists:
         self.uut.process_project_version_misuse(project, version, misuse)
         self.uut.end()
 
-        self.uut._unknown_dataset_entry.assert_not_called()
+        self.uut._report_unknown_dataset_entry.assert_not_called()
 
 
 class TestDatasetCheckUnknownLocation:
     def setup(self):
         self.uut = DatasetCheck({}, '', '')
-        self.uut._cannot_find_location = MagicMock()
+        self.uut._report_cannot_find_location = MagicMock()
 
         self.project = create_project("-project-", meta=EMPTY_META)
 
@@ -439,7 +439,7 @@ class TestDatasetCheckUnknownLocation:
         self.uut.process_project_version_misuse(self.project, self.version, self.misuse)
 
         self.uut._location_exists.assert_called_once_with("-checkout_dir-/-source_dir-", "-file-", "-method-")
-        self.uut._cannot_find_location.assert_called_once_with("Location(-file-, -method-)", "-project-/misuses/-id-/misuse.yml")
+        self.uut._report_cannot_find_location.assert_called_once_with("Location(-file-, -method-)", "-project-/misuses/-id-/misuse.yml")
 
     def test_known_location(self):
         self.uut._location_exists = MagicMock(return_value=True)
@@ -447,7 +447,7 @@ class TestDatasetCheckUnknownLocation:
         self.uut.process_project_version_misuse(self.project, self.version, self.misuse)
 
         self.uut._location_exists.assert_called_once_with("-checkout_dir-/-source_dir-", "-file-", "-method-")
-        self.uut._cannot_find_location.assert_not_called()
+        self.uut._report_cannot_find_location.assert_not_called()
 
 
 class TestDatasetCheckUnlistedMisuses:

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -44,9 +44,9 @@ class TestDatasetCheckProject:
 
     def test_version_and_misuse_with_same_name(self):
         self.uut._version_misuse_conflict = MagicMock()
-        project = create_project("-project-")
-        misuse = create_misuse("-conflict-", project=project)
-        version = create_version("-conflict-", project=project, misuses=[misuse])
+        project = create_project("-project-", meta={'empty': None})
+        misuse = create_misuse("-conflict-", project=project, meta={'empty': None})
+        version = create_version("-conflict-", project=project, misuses=[misuse], meta={'empty': None})
 
         self.uut.process_project(project)
 

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -85,6 +85,14 @@ class TestDatasetCheckProjectVersion:
 
         self.uut._missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
 
+    def test_misuses_none(self):
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta={"misuses": None}, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
+
     def test_missing_build(self):
         meta = {"misuses": ["1"]}
         project = create_project("-project-", meta={"empty": ''})
@@ -130,6 +138,18 @@ class TestDatasetCheckProjectVersion:
         self.uut.process_project_version(project, version)
 
         self.uut._missing_key.assert_any_call("build.src", "-project-/versions/-id-/version.yml")
+
+
+    def test_non_existent_misuse(self):
+        self.uut._unknown_misuse = MagicMock()
+        project = create_project("-project-")
+        version = create_version("-id-", meta={"misuses": ["-misuse-"]}, project=project)
+        version._MISUSES = []
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._unknown_misuse.assert_any_call(version.id, "-misuse-")
+
 
 class TestDatasetCheckMisuse:
     def setup(self):

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -496,7 +496,7 @@ class TestDatasetCheckUnlistedMisuses:
     def setup(self):
         self.uut = DatasetCheck({}, '', '')
         self.uut._check_misuse_location_exists = MagicMock()
-        self.uut._misuse_not_listed = MagicMock()
+        self.uut._report_misuse_not_listed = MagicMock()
 
     def test_misuse_not_listed_in_any_version(self):
         self.uut._get_all_misuses = MagicMock(return_value=["-project-.-misuse-"])
@@ -504,7 +504,7 @@ class TestDatasetCheckUnlistedMisuses:
         self.uut.start()
         self.uut.end()
 
-        self.uut._misuse_not_listed.assert_called_once_with("-project-.-misuse-")
+        self.uut._report_misuse_not_listed.assert_called_once_with("-project-.-misuse-")
 
     def test_listed_misuse_is_not_reported(self):
         self.uut._get_all_misuses = MagicMock(return_value=["-project-.-misuse-"])
@@ -516,4 +516,4 @@ class TestDatasetCheckUnlistedMisuses:
         self.uut.process_project_version_misuse(project, version, misuse)
         self.uut.end()
 
-        self.uut._misuse_not_listed.assert_not_called()
+        self.uut._report_misuse_not_listed.assert_not_called()

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -16,7 +16,7 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_called_with("name", "-id-/project.yml")
+        self.uut._missing_key.assert_any_call("name", "-id-/project.yml")
 
     def test_missing_repository(self):
         meta = {"name": "-project-name-"}
@@ -24,7 +24,7 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_called_with("repository", "-id-/project.yml")
+        self.uut._missing_key.assert_any_call("repository", "-id-/project.yml")
 
     def test_missing_repository_type(self):
         meta = {"name": "-project-name-", "repository": {"url": "https://github.com/stg-tud/MUBench.git"}}
@@ -32,7 +32,7 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_called_with("repository.type", "-id-/project.yml")
+        self.uut._missing_key.assert_any_call("repository.type", "-id-/project.yml")
 
     def test_missing_repository_url(self):
         meta = {"name": "-project-name-", "repository": {"type": "git"}}
@@ -40,4 +40,82 @@ class TestDatasetCheckProject:
 
         self.uut.process_project(project)
 
-        self.uut._missing_key.assert_called_with("repository.url", "-id-/project.yml")
+        self.uut._missing_key.assert_any_call("repository.url", "-id-/project.yml")
+
+class TestDatasetCheckProjectVersion:
+    def setup(self):
+        self.uut = DatasetCheck()
+        self.uut._missing_key = MagicMock()
+
+    def test_missing_revision(self):
+        meta = {"misuses": ["1"]}
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("revision", "-project-/-id-/version.yml")
+
+    def test_missing_misuses(self):
+        meta = {"revision": "1"}
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("misuses", "-project-/-id-/version.yml")
+
+    def test_missing_misuses(self):
+        meta = {"misuses": []}
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("misuses", "-project-/-id-/version.yml")
+
+    def test_missing_build(self):
+        meta = {"misuses": ["1"]}
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("build", "-project-/-id-/version.yml")
+
+    def test_missing_build_classes(self):
+        meta = {"build": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("build.classes", "-project-/-id-/version.yml")
+
+    def test_missing_build_commands(self):
+        meta = {"build": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("build.commands", "-project-/-id-/version.yml")
+
+    def test_empty_build_commands(self):
+        meta = {"build": {"commands": []}}
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("build.commands", "-project-/-id-/version.yml")
+
+
+    def test_missing_build_src(self):
+        meta = {"build": {}}
+        project = create_project("-project-", meta={"empty": ''})
+        version = create_version("-id-", meta=meta, project=project)
+
+        self.uut.process_project_version(project, version)
+
+        self.uut._missing_key.assert_any_call("build.src", "-project-/-id-/version.yml")

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -4,6 +4,7 @@ from nose.tools import assert_equals
 from tasks.implementations.dataset_check import DatasetCheck
 from tests.test_utils.data_util import create_project, create_version, create_misuse
 
+EMPTY_META = {"empty": None}
 
 class TestDatasetCheckProject:
     def setup(self):
@@ -44,9 +45,9 @@ class TestDatasetCheckProject:
 
     def test_version_and_misuse_with_same_name(self):
         self.uut._version_misuse_conflict = MagicMock()
-        project = create_project("-project-", meta={'empty': None})
-        misuse = create_misuse("-conflict-", project=project, meta={'empty': None})
-        version = create_version("-conflict-", project=project, misuses=[misuse], meta={'empty': None})
+        project = create_project("-project-", meta=EMPTY_META)
+        misuse = create_misuse("-conflict-", project=project, meta=EMPTY_META)
+        version = create_version("-conflict-", project=project, misuses=[misuse], meta=EMPTY_META)
 
         self.uut.process_project(project)
 
@@ -60,7 +61,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_missing_revision(self):
         meta = {"misuses": ["1"]}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
@@ -69,7 +70,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_missing_misuses(self):
         meta = {"revision": "1"}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
@@ -78,7 +79,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_empty_misuses(self):
         meta = {"misuses": []}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
@@ -86,7 +87,7 @@ class TestDatasetCheckProjectVersion:
         self.uut._missing_key.assert_any_call("misuses", "-project-/versions/-id-/version.yml")
 
     def test_misuses_none(self):
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta={"misuses": None}, project=project)
 
         self.uut.process_project_version(project, version)
@@ -95,7 +96,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_missing_build(self):
         meta = {"misuses": ["1"]}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
@@ -104,7 +105,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_missing_build_classes(self):
         meta = {"build": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
@@ -113,7 +114,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_missing_build_commands(self):
         meta = {"build": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
@@ -122,7 +123,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_empty_build_commands(self):
         meta = {"build": {"commands": []}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
@@ -132,7 +133,7 @@ class TestDatasetCheckProjectVersion:
 
     def test_missing_build_src(self):
         meta = {"build": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         version = create_version("-id-", meta=meta, project=project)
 
         self.uut.process_project_version(project, version)
@@ -157,11 +158,11 @@ class TestDatasetCheckMisuse:
         self.uut._missing_key = MagicMock()
 
     def test_missing_location(self):
-        meta = {"empty": ''}
-        project = create_project("-project-", meta={"empty": ''})
+        meta = EMPTY_META
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project)
         misuse._YAML = meta
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -169,9 +170,9 @@ class TestDatasetCheckMisuse:
 
     def test_missing_location_file(self):
         meta = {"location": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -179,9 +180,9 @@ class TestDatasetCheckMisuse:
 
     def test_missing_location_method(self):
         meta = {"location": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -189,19 +190,19 @@ class TestDatasetCheckMisuse:
 
     def test_missing_api(self):
         meta = {"empty": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
         self.uut._missing_key.assert_any_call("api", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_characteristics(self):
-        meta = {"empty": ''}
-        project = create_project("-project-", meta={"empty": ''})
+        meta = EMPTY_META
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -209,19 +210,19 @@ class TestDatasetCheckMisuse:
 
     def test_empty_characteristics(self):
         meta = {"characteristics": []}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
         self.uut._missing_key.assert_any_call("characteristics", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_description(self):
-        meta = {"empty": ''}
-        project = create_project("-project-", meta={"empty": ''})
+        meta = EMPTY_META
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -229,19 +230,19 @@ class TestDatasetCheckMisuse:
 
     def test_empty_description(self):
         meta = {"description": ''}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
         self.uut._missing_key.assert_any_call("description", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_fix(self):
-        meta = {"empty": ''}
-        project = create_project("-project-", meta={"empty": ''})
+        meta = EMPTY_META
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -249,9 +250,9 @@ class TestDatasetCheckMisuse:
 
     def test_missing_fix_commit(self):
         meta = {"fix": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -259,39 +260,39 @@ class TestDatasetCheckMisuse:
 
     def test_missing_fix_revision(self):
         meta = {"fix": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
         self.uut._missing_key.assert_any_call("fix.revision", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_internal(self):
-        meta = {"empty": ''}
-        project = create_project("-project-", meta={"empty": ''})
+        meta = EMPTY_META
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
         self.uut._missing_key.assert_any_call("internal", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_report(self):
-        meta = {"empty": ''}
-        project = create_project("-project-", meta={"empty": ''})
+        meta = EMPTY_META
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
         self.uut._missing_key.assert_any_call("report", "-project-/misuses/-id-/misuse.yml")
 
     def test_missing_source(self):
-        meta = {"empty": ''}
-        project = create_project("-project-", meta={"empty": ''})
+        meta = EMPTY_META
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -299,9 +300,9 @@ class TestDatasetCheckMisuse:
 
     def test_missing_source_name(self):
         meta = {"source": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -309,9 +310,9 @@ class TestDatasetCheckMisuse:
 
     def test_missing_source_url(self):
         meta = {"source": {}}
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         misuse = create_misuse("-id-", project=project, meta=meta)
-        version = create_version("-version-", meta={"empty": ''}, project=project, misuses=[misuse])
+        version = create_version("-version-", meta=EMPTY_META, project=project, misuses=[misuse])
 
         self.uut.process_project_version_misuse(project, version, misuse)
 
@@ -330,7 +331,7 @@ class TestDatasetCheckDatasetLists:
         self.uut._unknown_dataset_entry.assert_any_call("-dataset-", "-unknown-entry-")
 
     def test_no_warning_on_known_project(self):
-        project = create_project("-project-", meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
         self.uut.datasets = {"-dataset-": [project.id]}
 
         self.uut.process_project(project)
@@ -339,8 +340,8 @@ class TestDatasetCheckDatasetLists:
         self.uut._unknown_dataset_entry.assert_not_called()
 
     def test_no_warning_on_known_version(self):
-        project = create_project("-project-", meta={"empty": ''})
-        version = create_version("-version-", project=project, meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
+        version = create_version("-version-", project=project, meta=EMPTY_META)
         self.uut.datasets = {"-dataset-": [version.id]}
 
         self.uut.process_project_version(project, version)
@@ -349,9 +350,9 @@ class TestDatasetCheckDatasetLists:
         self.uut._unknown_dataset_entry.assert_not_called()
 
     def test_no_warning_on_known_misuse(self):
-        project = create_project("-project-", meta={"empty": ''})
-        misuse = create_misuse("-misuse-", project=project, meta={"empty": ''})
-        version = create_version("-version-", project=project, misuses=[misuse], meta={"empty": ''})
+        project = create_project("-project-", meta=EMPTY_META)
+        misuse = create_misuse("-misuse-", project=project, meta=EMPTY_META)
+        version = create_version("-version-", project=project, misuses=[misuse], meta=EMPTY_META)
         self.uut.datasets = {"-dataset-": [misuse.id]}
 
         self.uut.process_project_version_misuse(project, version, misuse)

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch, MagicMock, ANY
+from nose.tools import assert_equals
+
+from tasks.implementations.dataset_check import DatasetCheck
+from tests.test_utils.data_util import create_project, create_version, create_misuse
+
+
+class TestDatasetCheckProject:
+    def setup(self):
+        self.uut = DatasetCheck()
+        self.uut._missing_key = MagicMock()
+
+    def test_missing_name(self):
+        meta = {"repository": {"type": "git", "url": "https://github.com/stg-tud/MUBench.git"}}
+        project = create_project("-id-", meta=meta)
+
+        self.uut.process_project(project)
+
+        self.uut._missing_key.assert_called_with("name", "-id-/project.yml")
+
+    def test_missing_repository(self):
+        meta = {"name": "-project-name-"}
+        project = create_project("-id-", meta=meta)
+
+        self.uut.process_project(project)
+
+        self.uut._missing_key.assert_called_with("repository", "-id-/project.yml")
+
+    def test_missing_repository_type(self):
+        meta = {"name": "-project-name-", "repository": {"url": "https://github.com/stg-tud/MUBench.git"}}
+        project = create_project("-id-", meta=meta)
+
+        self.uut.process_project(project)
+
+        self.uut._missing_key.assert_called_with("repository.type", "-id-/project.yml")
+
+    def test_missing_repository_url(self):
+        meta = {"name": "-project-name-", "repository": {"type": "git"}}
+        project = create_project("-id-", meta=meta)
+
+        self.uut.process_project(project)
+
+        self.uut._missing_key.assert_called_with("repository.url", "-id-/project.yml")

--- a/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_dataset_check.py
@@ -70,6 +70,16 @@ class TestDatasetCheckProject:
 
         self.uut._report_id_conflict.assert_any_call("-project-.-conflict-")
 
+    def test_no_id_conflict_on_synthetic_repositories(self):
+        self.uut._report_id_conflict = MagicMock()
+        project = create_project("-project-", meta={"repository": {"type": "synthetic"}})
+        misuse = create_misuse("-conflict-", project=project, meta=EMPTY_META)
+        version = create_version("-conflict-", project=project, misuses=[misuse], meta=EMPTY_META)
+
+        self.uut.process_project(project)
+
+        self.uut._report_id_conflict.assert_not_called()
+
     def test_synthetic_no_url(self):
         meta = {"name": "-project-name-", "repository": {"type": "synthetic"}}
         project = create_project("-id-", meta=meta)

--- a/mubench.pipeline/tests/utils/test_command_line_util.py
+++ b/mubench.pipeline/tests/utils/test_command_line_util.py
@@ -143,3 +143,9 @@ def test_release_default():
     parser = get_command_line_parser(['valid-detector'], [], [])
     result = parser.parse_args(['detect', 'valid-detector', '1'])
     assert_equals(None, result.requested_release)
+
+
+def test_dataset_check():
+    parser = get_command_line_parser([], [], [])
+    result = parser.parse_args(['dataset-check'])
+    assert_equals('dataset-check', result.task)

--- a/mubench.pipeline/utils/command_line_util.py
+++ b/mubench.pipeline/utils/command_line_util.py
@@ -174,7 +174,7 @@ def __add_dataset_check_subprocess(available_datasets: List[str], subparsers) ->
     dataset_check_parser = subparsers.add_parser('dataset-check', formatter_class=SortingHelpFormatter,
                                                   help="Check the consistency of MUBench's dataset.",
                                                   description="Check the consistency of MUBench's dataset."
-                                                              "Run `checkout` to check misuse locations.")  # type: ArgumentParser
+                                                              "Run `checkout` first, to also check misuse locations.")  # type: ArgumentParser
     __setup_misuse_filter_arguments(dataset_check_parser, available_datasets)
 
 

--- a/mubench.pipeline/utils/command_line_util.py
+++ b/mubench.pipeline/utils/command_line_util.py
@@ -53,6 +53,7 @@ def get_command_line_parser(available_detectors: List[str], available_scripts: L
     __add_detect_subprocess(available_detectors, available_datasets, subparsers)
     __add_publish_subprocess(available_detectors, available_datasets, subparsers)
     __add_stats_subprocess(available_scripts, available_datasets, subparsers)
+    __add_dataset_check_subprocess(available_datasets, subparsers)
 
     return parser
 
@@ -167,6 +168,14 @@ def __add_stats_subprocess(available_scripts: List[str], available_datasets: Lis
     stats_parser.add_argument('script', help="the calculation strategy to use (case insensitive)",
                               choices=available_scripts)
     __setup_misuse_filter_arguments(stats_parser, available_datasets)
+
+
+def __add_dataset_check_subprocess(available_datasets: List[str], subparsers) -> None:
+    dataset_check_parser = subparsers.add_parser('dataset-check', formatter_class=SortingHelpFormatter,
+                                                  help="Check the consistency of MUBench's dataset.",
+                                                  description="Check the consistency of MUBench's dataset."
+                                                              "Run `checkout` to check misuse locations.")  # type: ArgumentParser
+    __setup_misuse_filter_arguments(dataset_check_parser, available_datasets)
 
 
 def __setup_misuse_filter_arguments(parser: ArgumentParser, available_datasets: List[str]):

--- a/mubench.pipeline/utils/dataset_util.py
+++ b/mubench.pipeline/utils/dataset_util.py
@@ -1,10 +1,16 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from utils.io import read_yaml
+
+
+def get_datasets(datasets_file_path: str) -> Dict[str, List[str]]:
+    return read_yaml(datasets_file_path)
+
 
 def get_available_datasets(datasets_file_path: str) -> List[str]:
     datasets = read_yaml(datasets_file_path)
     return list(datasets.keys())
+
 
 def get_white_list(datasets_file_path: str, dataset_key: Optional[str]) -> List[str]:
     if dataset_key is None:

--- a/mubench.pipeline/utils/dataset_util.py
+++ b/mubench.pipeline/utils/dataset_util.py
@@ -7,7 +7,7 @@ def get_datasets(datasets_file_path: str) -> Dict[str, List[str]]:
     return read_yaml(datasets_file_path)
 
 
-def get_available_datasets(datasets_file_path: str) -> List[str]:
+def get_available_dataset_ids(datasets_file_path: str) -> List[str]:
     datasets = read_yaml(datasets_file_path)
     return list(datasets.keys())
 

--- a/mubench.pipeline/utils/dataset_util.py
+++ b/mubench.pipeline/utils/dataset_util.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional
 from utils.io import read_yaml
 
 
-def get_datasets(datasets_file_path: str) -> Dict[str, List[str]]:
+def get_available_datasets(datasets_file_path: str) -> Dict[str, List[str]]:
     return read_yaml(datasets_file_path)
 
 


### PR DESCRIPTION
Implements #67

Misuse filter arguments may screw with some of the logic. We probably need to check for the white and black list in some cases, or omit the whole filter arguments feature and only allow a global check. I found it to be quite useful in some cases though. (Mainly to skip known issues.)

Logging seems a bit weird right now. I'm not sure how to improve it.