### PR TITLE
Temp dir option

### DIFF
--- a/mubench.bat
+++ b/mubench.bat
@@ -11,5 +11,5 @@ IF "%~1" == "configure" (
     echo "Choose one of {review-site}"
   )
 ) ELSE (
-  docker run --rm -v "%SCRIPT_DIR%":/mubench svamann/mubench python ./mubench.pipeline/benchmark.py %*
+  docker run --rm -v "%SCRIPT_DIR%":/mubench svamann/mubench python ./mubench.pipeline/benchmark.py --windows-fix %*
 )

--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -70,7 +70,8 @@ class Benchmark:
         self.runner.add(checkout_handler)
 
     def _setup_compile(self):
-        compile_handler = Compile(Benchmark.CHECKOUTS_PATH, Benchmark.COMPILES_PATH, self.config.force_compile)
+        compile_handler = Compile(Benchmark.CHECKOUTS_PATH, Benchmark.COMPILES_PATH,
+                                  self.config.force_compile, self.config.windows_fix)
         self.runner.add(compile_handler)
 
     def _setup_detect(self):

--- a/mubench.pipeline/tests/tasks/implementations/test_compile.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_compile.py
@@ -50,7 +50,7 @@ class TestCompile:
         self.pattern_classes_path = join(self.base_path, "patterns-classes")
         self.dep_path = join(self.base_path, "dependencies")
 
-        self.uut = Compile(self.checkout_base_path, self.compile_base_path, False)
+        self.uut = Compile(self.checkout_base_path, self.compile_base_path, False, False)
 
     def teardown(self):
         rmtree(self.temp_dir, ignore_errors=True)

--- a/mubench.pipeline/utils/command_line_util.py
+++ b/mubench.pipeline/utils/command_line_util.py
@@ -1,3 +1,4 @@
+import argparse
 from argparse import ArgumentParser, HelpFormatter, ArgumentTypeError
 from operator import attrgetter
 
@@ -45,6 +46,9 @@ def get_command_line_parser(available_detectors: List[str], available_scripts: L
     subparsers = parser.add_subparsers(
         help="MUBench provides several tasks. Run `mubench <task> -h` for details.",
         dest='task')
+
+    parser.add_argument('--windows-fix', dest='windows_fix', default=get_default('windows-fix', False),
+                        help=argparse.SUPPRESS, action='store_true')
 
     __add_check_subprocess(subparsers)
     __add_info_subprocess(available_datasets, subparsers)


### PR DESCRIPTION
Implementation for #46.
Compile now has the option to use a temporary directory. On successful completion, the directory is moved to the persistent standard directory. 
The new option is enabled by the `--windows-fix` flag, which is set in [mubench.bat](https://github.com/stg-tud/MUBench/blob/temp-dir-option/mubench.bat). Currently, this flag is hidden, i.e. not shown in the `mubench -h` text.

Note that checkouts still only use MUBench subdirectories. I am working on implementing that as well, but it is more complicated due to the local child repositories we create.