### PR TITLE
Resolve #118: Extract metadata controller

### DIFF
--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -22,27 +22,27 @@ class MetadataController
 
     function getMetadata($experimentId, Detector $detector, $projectId, $versionId, $misuseId)
     {
-        if ($experimentId === "ex1" || $experimentId === "ex3") {
+        if ($experimentId === 'ex1' || $experimentId === 'ex3') {
             $metadata = $this->db->table('metadata')
                 ->where('project', $projectId)->where('version', $versionId)->where('misuse', $misuseId)->first();
 
             $types = $this->db->table('misuse_types')->select('types.name')
                 ->innerJoin('types', 'misuse_types.type', '=', 'types.id')->where('project', $projectId)
                 ->where('version', $versionId)->where('misuse', $misuseId)->get();
-            $metadata["violation_types"] = [];
+            $metadata['violation_types'] = [];
             foreach($types as $type){
-                $metadata["violation_types"][] = $type['name'];
+                $metadata['violation_types'][] = $type['name'];
             }
 
-            if($experimentId === "ex1") {
-                $metadata["patterns"] = $this->getPatterns($misuseId);
+            if($experimentId === 'ex1') {
+                $metadata['patterns'] = $this->getPatterns($misuseId);
             }
-        } else { // if ($experimentId === "ex2")
-            $metadata = ["misuse" => $misuseId];
+        } else { // if ($experimentId === 'ex2')
+            $metadata = ['misuse' => $misuseId];
         }
 
-        $metadata["snippets"] = $this->getSnippets($experimentId, $detector, $projectId, $versionId, $misuseId);
-        $metadata["tags"] = $this->getTags($experimentId, $detector, $projectId, $versionId, $misuseId);
+        $metadata['snippets'] = $this->getSnippets($experimentId, $detector, $projectId, $versionId, $misuseId);
+        $metadata['tags'] = $this->getTags($experimentId, $detector, $projectId, $versionId, $misuseId);
 
         return $metadata;
     }
@@ -56,10 +56,10 @@ class MetadataController
     private function getSnippets($experimentId, Detector $detector, $projectId, $versionId, $misuseId)
     {
         $columns = ['line', 'snippet'];
-        if ($experimentId === "ex1" || $experimentId === "ex3") {
+        if ($experimentId === 'ex1' || $experimentId === 'ex3') {
             $query = $this->db->table('meta_snippets')
                 ->where('project', $projectId)->where('version', $versionId)->where('misuse', $misuseId);
-        } else { // if ($experimentId === "ex2")
+        } else { // if ($experimentId === 'ex2')
             $columns[] = 'id'; // SMELL meta_findings do not have an id
             $query = $this->db->table('finding_snippets')->where('detector', $detector->id)
                 ->where('project', $projectId)->where('version', $versionId)->where('finding', $misuseId);
@@ -79,7 +79,7 @@ class MetadataController
     {
         $metadata = $this->decodeJsonBody($request);
         if (!$metadata) {
-            return $this->respondWithError($response, $this->logger, 400, "empty: " . print_r($request->getBody(), true));
+            return $this->respondWithError($response, $this->logger, 400, 'empty: ' . print_r($request->getBody(), true));
         }
         foreach ($metadata as $misuseMetadata) {
             $projectId = $misuseMetadata['project'];
@@ -183,7 +183,7 @@ class MetadataController
         if ($body) return $body;
         $body = json_decode($request->getBody(), true);
         if ($body) return $body;
-        $body = json_decode($_POST["data"], true);
+        $body = json_decode($_POST['data'], true);
         return $body;
     }
 

--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -97,22 +97,6 @@ class MetadataController
         return $response->withStatus(200);
     }
 
-    // REFACTOR remove this, once it is no longer used
-    public function processMetaData($misuseMetadata)
-    {
-        $projectId = $misuseMetadata['project'];
-        $versionId = $misuseMetadata['version'];
-        $misuseId = $misuseMetadata['misuse'];
-        $description = $misuseMetadata['description'];
-        $fix = $misuseMetadata['fix'];
-        $location = $misuseMetadata['location'];
-        $violationTypes = $misuseMetadata['violation_types'];
-        $patterns = $misuseMetadata['patterns'];
-        $targetSnippets = $misuseMetadata['target_snippets'];
-
-        $this->updateMetadata($projectId, $versionId, $misuseId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets);
-    }
-
     function updateMetadata($projectId, $versionId, $misuseId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets)
     {
         $this->deleteMetadata($misuseId);

--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -113,7 +113,7 @@ class MetadataController
         $this->updateMetadata($misuseId, $projectId, $versionId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets);
     }
 
-    private function updateMetadata($misuseId, $projectId, $versionId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets)
+    function updateMetadata($misuseId, $projectId, $versionId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets)
     {
         $this->deleteMetadata($misuseId);
         $this->saveMetadata($projectId, $versionId, $misuseId, $description, $fix, $location);

--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -92,7 +92,7 @@ class MetadataController
             $patterns = $misuseMetadata['patterns'];
             $targetSnippets = $misuseMetadata['target_snippets'];
 
-            $this->updateMetadata($misuseId, $projectId, $versionId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets);
+            $this->updateMetadata($projectId, $versionId, $misuseId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets);
         }
         return $response->withStatus(200);
     }
@@ -110,10 +110,10 @@ class MetadataController
         $patterns = $misuseMetadata['patterns'];
         $targetSnippets = $misuseMetadata['target_snippets'];
 
-        $this->updateMetadata($misuseId, $projectId, $versionId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets);
+        $this->updateMetadata($projectId, $versionId, $misuseId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets);
     }
 
-    function updateMetadata($misuseId, $projectId, $versionId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets)
+    function updateMetadata($projectId, $versionId, $misuseId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets)
     {
         $this->deleteMetadata($misuseId);
         $this->saveMetadata($projectId, $versionId, $misuseId, $description, $fix, $location);

--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -4,6 +4,8 @@ namespace MuBench\ReviewSite\Controller;
 
 use Monolog\Logger;
 use MuBench\ReviewSite\DBConnection;
+use Slim\Http\Request;
+use Slim\Http\Response;
 
 class MetadataController
 {
@@ -17,82 +19,110 @@ class MetadataController
         $this->logger = $logger;
     }
 
-    public function processMetaData($json)
+    public function update(Request $request, Response $response, array $args)
     {
-        $project = $json->{'project'};
-        $version = $json->{'version'};
-        $misuse = $json->{'misuse'};
-        $this->deleteMetadata($json->{'misuse'});
-        $this->deletePatterns($json->{'misuse'});
-        $this->logger->info("saving metadata for $project, $version, $misuse");
-        $this->insertMetadata($project, $version, $misuse, $json->{'description'}, $json->{'fix'}->{'description'},
-            $json->{'fix'}->{'diff-url'}, $json->{'location'}->{'file'}, $json->{'location'}->{'method'});
-        $this->addViolationTypesToMisuse($project, $version, $misuse, $json->{'violation_types'});
-
-        foreach ($json->{'patterns'} as $p) {
-            $this->insertPattern($misuse, $p->{'id'}, $p->{'snippet'}->{'code'}, $p->{'snippet'}->{'first_line'});
+        $metadata = $this->decodeJsonBody($request);
+        if (!$metadata) {
+            return $this->respondWithError($response, $this->logger, 400, "empty: " . print_r($request->getBody(), true));
         }
-        if($json->{'target_snippets'}) {
-            foreach ($json->{'target_snippets'} as $snippet) {
-                $this->getMetaSnippetStatement($project, $version, $misuse, $snippet->{'code'}, $snippet->{'first_line_number'});
-            }
+        foreach ($metadata as $misuseMetadata) {
+            $this->processMetaData($misuseMetadata);
         }
+        return $response->withStatus(200);
     }
 
-    private function deleteMetadata($misuse)
+    // REFACTOR inline this into the method above, once it is no longer used
+    public function processMetaData($misuseMetadata)
     {
-        $this->db->table('metadata')->where('misuse', $misuse)->delete();
+        $projectId = $misuseMetadata['project'];
+        $versionId = $misuseMetadata['version'];
+        $misuseId = $misuseMetadata['misuse'];
+        $description = $misuseMetadata['description'];
+        $fix = $misuseMetadata['fix'];
+        $location = $misuseMetadata['location'];
+        $violationTypes = $misuseMetadata['violation_types'];
+        $patterns = $misuseMetadata['patterns'];
+        $targetSnippets = $misuseMetadata['target_snippets'];
+
+        $this->updateMetadata($misuseId, $projectId, $versionId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets);
     }
 
-    private function deletePatterns($misuse)
+    private function updateMetadata($misuseId, $projectId, $versionId, $description, $fix, $location, $violationTypes, $patterns, $targetSnippets)
     {
-        $this->db->table('patterns')->where('misuse', $misuse)->delete();
+        $this->deleteMetadata($misuseId);
+        $this->saveMetadata($projectId, $versionId, $misuseId, $description, $fix, $location);
+        $this->saveViolationTypes($projectId, $versionId, $misuseId, $violationTypes);
+        $this->savePatterns($misuseId, $patterns);
+        $this->saveTargetSnippets($misuseId, $projectId, $versionId, $targetSnippets);
     }
 
-    private function insertMetadata($project, $version, $misuse, $desc, $fix_desc, $diff_url, $file, $method)
+    private function deleteMetadata($misuseId)
     {
-        $this->db->table('metadata')->insert(['project' => $project, 'version' => $version, 'misuse' => $misuse,
-            'description' => $desc, 'fix_description' => $fix_desc, 'diff_url' => $diff_url, 'file' => $file, 'method' => $method]);
+        $this->logger->info("delete metadata for misuse $misuseId");
+        $this->db->table('metadata')->where('misuse', $misuseId)->delete();
+        $this->db->table('patterns')->where('misuse', $misuseId)->delete();
     }
 
-    private function addViolationTypesToMisuse($project, $version, $misuse, $violation_types)
+    private function saveMetadata($projectId, $versionId, $misuseId, $description, $fix, $location)
     {
-        $this->logger->info("saving violation types for misuse");
-        foreach($violation_types as $type_name){
+        $this->logger->info("saving metadata for $projectId, $versionId, $misuseId");
+        $this->db->table('metadata')->insert(['project' => $projectId, 'version' => $versionId, 'misuse' => $misuseId,
+            'description' => $description, 'fix_description' => $fix['description'], 'diff_url' => $fix['diff-url'],
+            'file' => $location['file'], 'method' => $location['method']]);
+    }
+
+    private function saveViolationTypes($projectId, $versionId, $misuseId, $violationTypes)
+    {
+        $this->logger->info("saving violation types for $projectId, $versionId, $misuseId");
+        foreach ($violationTypes as $type_name) {
             $violation_type = $this->getOrCreateViolationType($type_name);
             $this->logger->info(print_r($violation_type, true));
-            $this->db->table('misuse_types')->insert(['project' => $project, 'version' => $version, 'misuse' => $misuse, 'type' => $violation_type['id']]);
+            $this->db->table('misuse_types')->insert(['project' => $projectId, 'version' => $versionId, 'misuse' => $misuseId, 'type' => $violation_type['id']]);
         }
     }
 
-    private function getOrCreateViolationType($violation_type)
+    private function getOrCreateViolationType($violationType)
     {
-        $type = $this->db->table('types')->where('name', $violation_type)->first();
+        $type = $this->db->table('types')->where('name', $violationType)->first();
         if(!$type) {
-            $this->db->table('types')->insert(['name' => $violation_type]);
-            $type = $this->db->table('types')->where('name', $violation_type)->first();
+            $this->db->table('types')->insert(['name' => $violationType]);
+            $type = $this->db->table('types')->where('name', $violationType)->first();
         }
         return $type;
     }
 
-    private function insertPattern($misuse, $id, $code, $line)
+    private function savePatterns($misuseId, $patterns)
     {
-        $this->db->table('patterns')->insert(['misuse' => $misuse, 'name' => $id, 'code' => $code, 'line' => $line]);
-    }
-
-    private function getMetaSnippetStatement($project, $version, $misuse, $snippet, $line)
-    {
-        $this->db->table('meta_snippets')->insert(['project' => $project, 'version' => $version, 'misuse' => $misuse,
-            'snippet' => $snippet, 'line' => $line]);
-    }
-
-    private function arrayToString($json)
-    {
-        $out = $json[0];
-        for ($i = 1; $i < count($json); $i++) {
-            $out = $out . ';' . $json[$i];
+        if ($patterns) {
+            foreach ($patterns as $pattern) {
+                $this->db->table('patterns')->insert(['misuse' => $misuseId, 'name' => $pattern['id'],
+                    'code' => $pattern['snippet']['code'], 'line' => $pattern['snippet']['first_line']]);
+            }
         }
-        return $out;
     }
 
+    private function saveTargetSnippets($misuseId, $projectId, $versionId, $targetSnippets)
+    {
+        if ($targetSnippets) {
+            foreach ($targetSnippets as $snippet) {
+                $this->db->table('meta_snippets')->insert(['project' => $projectId, 'version' => $versionId,
+                    'misuse' => $misuseId, 'snippet' => $snippet['code'], 'line' => $snippet['first_line_number']]);
+            }
+        }
+    }
+
+    function decodeJsonBody(Request $request) {
+        $requestBody = $request->getParsedBody();
+        $body = json_decode($requestBody, true);
+        if ($body) return $body;
+        $body = json_decode($request->getBody(), true);
+        if ($body) return $body;
+        $body = json_decode($_POST["data"], true);
+        return $body;
+    }
+
+    function respondWithError(Response $response, Logger $logger, $code, $message) {
+        $logger->error($message);
+        return $response->withStatus($code)->write($message);
+    }
 }

--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -38,7 +38,7 @@ class MetadataController
                 $metadata['patterns'] = $this->getPatterns($misuseId);
             }
         } else { // if ($experimentId === 'ex2')
-            $metadata = ['misuse' => $misuseId];
+            $metadata = ['project' => $projectId, 'version' => $versionId, 'misuse' => $misuseId];
         }
 
         $metadata['snippets'] = $this->getSnippets($experimentId, $detector, $projectId, $versionId, $misuseId);

--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -5,7 +5,7 @@ namespace MuBench\ReviewSite\Controller;
 use Monolog\Logger;
 use MuBench\ReviewSite\DBConnection;
 
-class MetadataUploader
+class MetadataController
 {
 
     private $db;

--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -20,6 +20,10 @@ class MetadataController
         $this->logger = $logger;
     }
 
+    // REFACTOR retrieving metadata should not depend on an experiment or a detector. The metadata is global.
+    // We should query the metadata table by (project, version, misuse) and return the minimal information if this
+    // returns no result. The snippets should be handled by an independent controller. The tags are not part of the
+    // metadata and should be handled by an independent controller.
     function getMetadata($experimentId, Detector $detector, $projectId, $versionId, $misuseId)
     {
         if ($experimentId === 'ex1' || $experimentId === 'ex3') {

--- a/mubench.reviewsite/src/route_utils.php
+++ b/mubench.reviewsite/src/route_utils.php
@@ -4,6 +4,8 @@ use Monolog\Logger;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
+# REFACTOR delete this after migration to controllers
+
 function decodeJsonBody(Request $request) {
     $requestBody = $request->getParsedBody();
     $body = json_decode($requestBody);

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -55,7 +55,7 @@ $app->group('/download', function () use ($app, $downloadController, $database) 
 });
 
 
-$app->group('/api/upload', function () use ($app, $settings, $database, $reviewController) {
+$app->group('/api/upload', function () use ($app, $settings, $database, $logger, $reviewController) {
     $app->post('/[{experiment:ex[1-3]}]',
         function (Request $request, Response $response, array $args) use ($settings, $database) {
             $experiment = $args['experiment'];
@@ -91,19 +91,7 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $reviewC
             return $response->withStatus(200);
         });
 
-    $app->post('/metadata',
-        function (Request $request, Response $response, array $args) use ($database) {
-            $obj = decodeJsonBody($request);
-            if (!$obj) {
-                return error_response($response, $this->logger, 400, "empty: " . print_r($request->getBody(), true));
-            }
-            $uploader = new MetadataController($database, $this->logger);
-            foreach ($obj as $o) {
-                $uploader->processMetaData($o);
-            }
-            return $response->withStatus(200);
-        });
-
+    $app->post('/metadata', [new MetadataController($database, $logger), "update"]);
     $app->post('/review/{exp:ex[1-3]}/{detector}', [$reviewController, "update"]);
 
     $app->post('/delete/snippet/{exp:ex[1-3]}/{detector}',

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -2,7 +2,7 @@
 /** @var \Slim\App $app */
 
 use MuBench\ReviewSite\Controller\FindingsUploader;
-use MuBench\ReviewSite\Controller\MetadataUploader;
+use MuBench\ReviewSite\Controller\MetadataController;
 use MuBench\ReviewSite\Controller\ReviewController;
 use MuBench\ReviewSite\Controller\ReviewUploader;
 use MuBench\ReviewSite\Controller\SnippetUploader;
@@ -97,7 +97,7 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $reviewC
             if (!$obj) {
                 return error_response($response, $this->logger, 400, "empty: " . print_r($request->getBody(), true));
             }
-            $uploader = new MetadataUploader($database, $this->logger);
+            $uploader = new MetadataController($database, $this->logger);
             foreach ($obj as $o) {
                 $uploader->processMetaData($o);
             }

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -23,7 +23,8 @@ $renderer = $app->getContainer()['renderer'];
 // REFACTOR rename RoutesHelper to ResultsViewController
 $routesHelper = new RoutesHelper($database, $renderer, $logger, $settings['upload'], $settings['site_base_url'], $settings['default_ex2_review_size']);
 $downloadController = new DownloadController($database, $logger, $settings['default_ex2_review_size']);
-$reviewController = new ReviewController($settings["site_base_url"], $settings["upload"], $database, $renderer);
+$metadataController = new MetadataController($database, $logger);
+$reviewController = new ReviewController($settings["site_base_url"], $settings["upload"], $database, $renderer, $metadataController);
 
 $app->get('/', [$routesHelper, 'index']);
 $app->get('/{exp:ex[1-3]}/{detector}', [$routesHelper, 'detector']);
@@ -55,7 +56,7 @@ $app->group('/download', function () use ($app, $downloadController, $database) 
 });
 
 
-$app->group('/api/upload', function () use ($app, $settings, $database, $logger, $reviewController) {
+$app->group('/api/upload', function () use ($app, $settings, $database, $metadataController, $reviewController) {
     $app->post('/[{experiment:ex[1-3]}]',
         function (Request $request, Response $response, array $args) use ($settings, $database) {
             $experiment = $args['experiment'];
@@ -91,7 +92,7 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $logger,
             return $response->withStatus(200);
         });
 
-    $app->post('/metadata', [new MetadataController($database, $logger), "update"]);
+    $app->post('/metadata', [$metadataController, "update"]);
     $app->post('/review/{exp:ex[1-3]}/{detector}', [$reviewController, "update"]);
 
     $app->post('/delete/snippet/{exp:ex[1-3]}/{detector}',

--- a/mubench.reviewsite/tests/DatabaseTestCase.php
+++ b/mubench.reviewsite/tests/DatabaseTestCase.php
@@ -20,61 +20,6 @@ class DatabaseTestCase extends TestCase
      */
     protected $db;
 
-    protected $finding_json = <<<EOT
-    {
-        "detector": "-d-",
-        "project": "-p-",
-        "version": "-v-",
-        "result": "success",
-        "runtime": 42.1,
-        "number_of_findings": 23,
-        "potential_hits": [
-            {
-                "misuse": "-m-",
-                "rank": 0,
-                "target_snippets": [
-                    {"first_line_number": 5, "code": "-code-"}
-                ],
-                "custom1": "-val1-",
-                "custom2": "-val2-"
-            }
-        ]
-    }
-EOT;
-
-    protected $metadata_json = <<<EOD
-{
-    "project": "-p-",
-    "version": "-v-",
-    "misuse": "-m-",
-    "patterns": [
-        {
-            "snippet": {
-                "first_line": 1,
-                "code": "-pattern-code-"
-            },
-            "id": "-p-id-"
-        }
-    ],
-    "violation_types": ["superfluous/condition/null_check"],
-    "target_snippets": [
-        {
-            "first_line_number": 273,
-            "code": "-code-"
-        }
-    ],
-    "description": "-desc-",
-    "location": {
-        "file": "-f-",
-        "method": "-method-"
-    },
-    "fix":{
-        "diff-url": "-diff-",
-        "description": "-fix-desc-"
-    }
-}
-EOD;
-
     function setUp()
     {
         $connection = new \Pixie\Connection('sqlite', ['driver' => 'sqlite', 'database' => ':memory:']);

--- a/mubench.reviewsite/tests/ReviewControllerTest.php
+++ b/mubench.reviewsite/tests/ReviewControllerTest.php
@@ -24,7 +24,9 @@ class ReviewControllerTest extends DatabaseTestCase
     {
         parent::setUp();
         $this->detector = $this->db->getOrCreateDetector('-d-');
-        $this->reviewController = new ReviewController('', '', $this->db, new PhpRenderer());
+        $metadataController = new MetadataController($this->db, $this->logger);
+        $renderer = new PhpRenderer();
+        $this->reviewController = new ReviewController('', '', $this->db, $renderer, $metadataController);
     }
 
 
@@ -122,8 +124,8 @@ class ReviewControllerTest extends DatabaseTestCase
         ];
 
         $detector = new Detector('-d-', 1);
-        $metadataUploader = new MetadataUploader($this->db, $this->logger);
-        $metadataUploader->processMetaData(json_decode(json_encode($metadata)));
+        $metadataController = new MetadataController($this->db, $this->logger);
+        $metadataController->processMetaData($metadata);
         $findingUploader = new FindingsUploader($this->db, $this->logger);
         $findingUploader->processData('ex1', json_decode(json_encode($finding)));
 

--- a/mubench.reviewsite/tests/ReviewControllerTest.php
+++ b/mubench.reviewsite/tests/ReviewControllerTest.php
@@ -93,39 +93,27 @@ class ReviewControllerTest extends DatabaseTestCase
             ]
         ];
 
-        $metadata = [
-            "project" => "-p-",
-            "version" => "-v-",
-            "misuse" => "-m-",
-            "patterns" => [
-                [
-                    "snippet" => [
-                        "first_line" => 1,
-                        "code" => "-pattern-code-",
-
-                    ],
-                    "id" => "-p-id-"
-                ]
-            ],
-            "violation_types" => ["superfluous/condition/null_check"],
-            "target_snippets" => [[
-                'code' => '-code-',
-                'first_line_number' => 273
-            ]],
-            "description" => "-desc-",
-            "location" => [
-                "file" => "-f-",
-                "method" => "-method-"
-            ],
-            "fix" => [
-                'description' => '-fix-desc-',
-                'diff-url' => '-diff-'
-            ]
-        ];
-
         $detector = new Detector('-d-', 1);
         $metadataController = new MetadataController($this->db, $this->logger);
-        $metadataController->processMetaData($metadata);
+        $metadataController->updateMetadata('-p-', '-v-', '-m-', '-desc-', [
+            'description' => '-fix-desc-',
+            'diff-url' => '-diff-'
+        ], [
+            "file" => "-f-",
+            "method" => "-method-"
+        ], ["superfluous/condition/null_check"], [
+            [
+                "snippet" => [
+                    "first_line" => 1,
+                    "code" => "-pattern-code-",
+
+                ],
+                "id" => "-p-id-"
+            ]
+        ], [[
+            'code' => '-code-',
+            'first_line_number' => 273
+        ]]);
         $findingUploader = new FindingsUploader($this->db, $this->logger);
         $findingUploader->processData('ex1', json_decode(json_encode($finding)));
 
@@ -189,6 +177,8 @@ class ReviewControllerTest extends DatabaseTestCase
 
         $expectedMisuse = new Misuse(
             [
+                'project' => '-p-',
+                'version' => '-v-',
                 'misuse' => 0,
                 'snippets' => [],
                 'tags' => []

--- a/mubench.reviewsite/tests/StoreFindingsTest.php
+++ b/mubench.reviewsite/tests/StoreFindingsTest.php
@@ -3,7 +3,7 @@
 require_once "DatabaseTestCase.php";
 
 use MuBench\ReviewSite\Controller\FindingsUploader;
-use MuBench\ReviewSite\Controller\MetadataUploader;
+use MuBench\ReviewSite\Controller\MetadataController;
 use MuBench\ReviewSite\Controller\SnippetUploader;
 use MuBench\ReviewSite\Model\Misuse;
 
@@ -137,7 +137,7 @@ class StoreFindingsTest extends DatabaseTestCase
 
     function test_get_misuse_ex1(){
         $finding_uploader = new FindingsUploader($this->db, $this->logger);
-        $metadata_uploader = new MetadataUploader($this->db, $this->logger);
+        $metadata_uploader = new MetadataController($this->db, $this->logger);
 
         $data = json_decode($this->finding_json);
         $metadata = json_decode($this->metadata_json);

--- a/mubench.reviewsite/tests/StoreFindingsTest.php
+++ b/mubench.reviewsite/tests/StoreFindingsTest.php
@@ -140,7 +140,7 @@ class StoreFindingsTest extends DatabaseTestCase
         $metadata_uploader = new MetadataController($this->db, $this->logger);
 
         $data = json_decode($this->finding_json);
-        $metadata = json_decode($this->metadata_json);
+        $metadata = json_decode($this->metadata_json, true);
         $finding_uploader->processData("ex1", $data);
         $metadata_uploader->processMetaData($metadata);
         $detector = $this->db->getOrCreateDetector("-d-");

--- a/mubench.reviewsite/tests/StoreFindingsTest.php
+++ b/mubench.reviewsite/tests/StoreFindingsTest.php
@@ -137,11 +137,11 @@ class StoreFindingsTest extends DatabaseTestCase
 
     function test_get_misuse_ex1(){
         $metadataController = new MetadataController($this->db, $this->logger);
-        $metadataController->updateMetadata('-m-', '-p-', '-v-', '-desc-',
+        // SMELL currently, this test depends on a pattern in the metadata, because otherwise the metadata is not
+        // found for ex1. This should not be necessary anymore, once the findings controller is separated.
+        $metadataController->updateMetadata('-p-', '-v-', '-m-', '-desc-',
             ['diff-url' => '-diff-', 'description' => '-fix-desc-'],
             ['file' => '-file-location-', 'method' => '-method-location-'], [],
-            // SMELL currently, this test depends on a pattern being present, because otherwise the metadata is not
-            // found. This should not be necessary anymore, once the findings controller is separated.
             [['id' => '-p1-', 'snippet' => ['code' => '-code-', 'first_line' => 42]]], []);
 
         $findingsUploader = new FindingsUploader($this->db, $this->logger);

--- a/mubench.reviewsite/tests/StoreMetadataTest.php
+++ b/mubench.reviewsite/tests/StoreMetadataTest.php
@@ -39,4 +39,20 @@ class StoreMetadataTest extends DatabaseTestCase
         ], $metadata);
     }
 
+    function test_e2_metadata()
+    {
+        $detector = $this->db->getOrCreateDetector('-d-');
+        $metadataController = new MetadataController($this->db, $this->logger);
+
+        $metadata = $metadataController->getMetadata('ex2', $detector, '-p-', '-v-', '-m-');
+
+        self::assertEquals([
+            'project' => '-p-',
+            'version' => '-v-',
+            'misuse' => '-m-',
+            'snippets' => [],
+            'tags' => []
+        ], $metadata);
+    }
+
 }

--- a/mubench.reviewsite/tests/StoreMetadataTest.php
+++ b/mubench.reviewsite/tests/StoreMetadataTest.php
@@ -13,7 +13,7 @@ class StoreMetadataTest extends DatabaseTestCase
         $detector = $this->db->getOrCreateDetector('-d-');
         $metadataController = new MetadataController($this->db, $this->logger);
 
-        $metadataController->updateMetadata('-m-', '-p-', '-v-', '-desc-',
+        $metadataController->updateMetadata('-p-', '-v-', '-m-', '-desc-',
             ['diff-url' => '-diff-', 'description' => '-fix-desc-'],
             ['file' => '-file-location-', 'method' => '-method-location-'],
             ['missing/call'],

--- a/mubench.reviewsite/tests/StoreMetadataTest.php
+++ b/mubench.reviewsite/tests/StoreMetadataTest.php
@@ -3,7 +3,7 @@
 require_once "DatabaseTestCase.php";
 
 use MuBench\ReviewSite\Controller\FindingsUploader;
-use MuBench\ReviewSite\Controller\MetadataUploader;
+use MuBench\ReviewSite\Controller\MetadataController;
 use MuBench\ReviewSite\Model\Misuse;
 
 class StoreMetadataTest extends DatabaseTestCase
@@ -11,7 +11,7 @@ class StoreMetadataTest extends DatabaseTestCase
     function test_store_metadata()
     {
         $finding_uploader = new FindingsUploader($this->db, $this->logger);
-        $metadata_uploader = new MetadataUploader($this->db, $this->logger);
+        $metadata_uploader = new MetadataController($this->db, $this->logger);
 
         $data = json_decode($this->metadata_json);
         $findings = json_decode($this->finding_json);

--- a/mubench.reviewsite/tests/StoreMetadataTest.php
+++ b/mubench.reviewsite/tests/StoreMetadataTest.php
@@ -1,66 +1,42 @@
 <?php
 
+namespace MuBench\ReviewSite\Controller;
+
 require_once "DatabaseTestCase.php";
 
-use MuBench\ReviewSite\Controller\FindingsUploader;
-use MuBench\ReviewSite\Controller\MetadataController;
-use MuBench\ReviewSite\Model\Misuse;
+use DatabaseTestCase;
 
 class StoreMetadataTest extends DatabaseTestCase
 {
     function test_store_metadata()
     {
-        $finding_uploader = new FindingsUploader($this->db, $this->logger);
-        $metadata_uploader = new MetadataController($this->db, $this->logger);
-
-        $data = json_decode($this->metadata_json, true);
-        $findings = json_decode($this->finding_json);
-
-        $finding_uploader->processData('ex1', $findings);
-        $metadata_uploader->processMetaData($data);
-
         $detector = $this->db->getOrCreateDetector('-d-');
-        $runs = $this->db->getRuns($detector, 'ex1');
+        $metadataController = new MetadataController($this->db, $this->logger);
 
-        $expected_run = [
-            "exp" => "ex1",
-            "project" => "-p-",
-            "version" => "-v-",
-            "result" => "success",
-            "runtime" => "42.1",
-            "number_of_findings" => "23",
-            "misuses" => [
-                new Misuse(
-                    [
-                    'misuse' => '-m-',
-                    'project' => '-p-',
-                    'version' => '-v-',
-                    'description' => '-desc-',
-                    'fix_description' => '-fix-desc-',
-                    'violation_types' => [0 => 'superfluous/condition/null_check'],
-                    'file' => '-f-',
-                    'method' => '-method-',
-                    'diff_url' => '-diff-',
-                    'snippets' => [0 => ['line' => '273', 'snippet' => '-code-']],
-                    'patterns' => [0 => ['name' => '-p-id-', 'code' => '-pattern-code-','line' => '1']],
-                    'tags' => []
-                    ],
-                    [
-                        [
-                            'exp' => 'ex1',
-                            'project' => '-p-',
-                            'version' => '-v-',
-                            'misuse' => '-m-',
-                            'rank' => '0',
-                            'custom1' => '-val1-',
-                            'custom2' => '-val2-'
-                        ]
-                    ],
-                    [])
-            ]
-        ];
+        $metadataController->updateMetadata('-m-', '-p-', '-v-', '-desc-',
+            ['diff-url' => '-diff-', 'description' => '-fix-desc-'],
+            ['file' => '-file-location-', 'method' => '-method-location-'],
+            ['missing/call'],
+            [['id' => '-p1-', 'snippet' => ['code' => '-pattern-code-', 'first_line' => 42]]],
+            [['code' => '-target-snippet-code-', 'first_line_number' => 273]]);
 
-        self::assertEquals([$expected_run], $runs);
+        $metadata = $metadataController->getMetadata('ex1', $detector, '-p-', '-v-', '-m-');
+
+        self::assertEquals([
+            'project' => '-p-',
+            'version' => '-v-',
+            'misuse' => '-m-',
+            // REFACTOR merge description and fix description
+            'description' => '-desc-',
+            'fix_description' => '-fix-desc-',
+            'violation_types' => [0 => 'missing/call'],
+            'file' => '-file-location-',
+            'method' => '-method-location-',
+            'diff_url' => '-diff-',
+            'snippets' => [0 => ['snippet' => '-target-snippet-code-', 'line' => 273]],
+            'patterns' => [0 => ['name' => '-p1-', 'code' => '-pattern-code-','line' => 42]],
+            'tags' => []
+        ], $metadata);
     }
 
 }

--- a/mubench.reviewsite/tests/StoreMetadataTest.php
+++ b/mubench.reviewsite/tests/StoreMetadataTest.php
@@ -13,7 +13,7 @@ class StoreMetadataTest extends DatabaseTestCase
         $finding_uploader = new FindingsUploader($this->db, $this->logger);
         $metadata_uploader = new MetadataController($this->db, $this->logger);
 
-        $data = json_decode($this->metadata_json);
+        $data = json_decode($this->metadata_json, true);
         $findings = json_decode($this->finding_json);
 
         $finding_uploader->processData('ex1', $findings);


### PR DESCRIPTION
Pulled all parts controlling the metadata into a dedicated class. There's room for improvement, w.r.t. the separation of meta data and result data (snippets and tags), but this is not too bad for now. Please have a look at what I did and if you agree with where this is going. I tried to commit in small steps to you can follow my progress.