### PR TITLE
Resolve #121: Extract misuse-tags controller

### DIFF
--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -14,14 +14,11 @@ class MetadataController
     private $db;
     /** @var Logger */
     private $logger;
-    /** @var MisuseTagsController */
-    private $tagController;
 
-    function __construct(DBConnection $db, Logger $logger, MisuseTagsController $tagController)
+    function __construct(DBConnection $db, Logger $logger)
     {
         $this->db = $db;
         $this->logger = $logger;
-        $this->tagController = $tagController;
     }
 
     // REFACTOR retrieving metadata should not depend on an experiment or a detector. The metadata is global.
@@ -50,7 +47,6 @@ class MetadataController
         }
 
         $metadata['snippets'] = $this->getSnippets($experimentId, $detector, $projectId, $versionId, $misuseId);
-        $metadata['tags'] = $this->tagController->getTags($experimentId, $detector, $projectId, $versionId, $misuseId);
 
         return $metadata;
     }

--- a/mubench.reviewsite/src/Controller/MetadataController.php
+++ b/mubench.reviewsite/src/Controller/MetadataController.php
@@ -14,10 +14,10 @@ class MetadataController
     private $db;
     /** @var Logger */
     private $logger;
-    /** @var TagController */
+    /** @var MisuseTagsController */
     private $tagController;
 
-    function __construct(DBConnection $db, Logger $logger, TagController $tagController)
+    function __construct(DBConnection $db, Logger $logger, MisuseTagsController $tagController)
     {
         $this->db = $db;
         $this->logger = $logger;

--- a/mubench.reviewsite/src/Controller/MisuseTagsController.php
+++ b/mubench.reviewsite/src/Controller/MisuseTagsController.php
@@ -57,18 +57,26 @@ class MisuseTagsController
         }
     }
 
-    public function deleteMisuseTag($misuse)
+    public function delete(Request $request, Response $response, array $args)
     {
-        $tag = $misuse['tag'];
-        $experiment = $misuse['exp'];
-        $detector = $misuse['detector'];
-        $project = $misuse['project'];
-        $version = $misuse['version'];
-        $misuse_id = $misuse['misuse'];
-        $this->logger->info("deleting tag $tag for $detector, $project, $version, $misuse_id");
-        $this->db->table('misuse_tags')->where('exp', $experiment)->where('detector', $detector)
-            ->where('project', $project)->where('version', $version)->where('misuse', $misuse_id)->where('tag', $tag)
-            ->delete();
+        $formData = $request->getParsedBody();
+        $tagName = $formData['tag'];
+        $experimentId = $formData['exp'];
+        $detector = $this->db->getDetector($formData['detector']);
+        $projectId = $formData['project'];
+        $versionId = $formData['version'];
+        $misuseId = $formData['misuse'];
+        $this->deleteTag($experimentId, $detector, $projectId, $versionId, $misuseId, $tagName);
+        return $this->redirectBack($response, $formData);
+    }
+
+    public function deleteTag($experimentId, Detector $detector, $projectId, $versionId, $misuseId, $tagName)
+    {
+        $tag = $this->getOrCreateTag($tagName);
+        $this->logger->info("Remove tag {$tag['id']}:{$tag['name']} from $experimentId, $detector, $projectId, $versionId, $misuseId");
+        $this->db->table('misuse_tags')->where('exp', $experimentId)->where('detector', $detector->id)
+            ->where('project', $projectId)->where('version', $versionId)->where('misuse', $misuseId)
+            ->where('tag', $tag['id'])->delete();
     }
 
     private function getOrCreateTag($name)

--- a/mubench.reviewsite/src/Controller/MisuseTagsController.php
+++ b/mubench.reviewsite/src/Controller/MisuseTagsController.php
@@ -8,7 +8,7 @@ use MuBench\ReviewSite\Model\Detector;
 use Slim\Http\Request;
 use Slim\Http\Response;
 
-class TagController
+class MisuseTagsController
 {
 
     private $db;

--- a/mubench.reviewsite/src/Controller/MisuseTagsController.php
+++ b/mubench.reviewsite/src/Controller/MisuseTagsController.php
@@ -79,18 +79,22 @@ class MisuseTagsController
             ->where('tag', $tag['id'])->delete();
     }
 
-    private function getOrCreateTag($name)
+    private function getOrCreateTag($tagName)
     {
-        $tag = $this->db->table('tags')->where('name', $name)->get();
-        if (!$tag) {
-            $this->saveNewTag($name);
+        if (!$this->getTag($tagName)) {
+            $this->createTag($tagName);
         }
-        return $this->db->table('tags')->where('name', $name)->first();
+        return $this->getTag($tagName);
     }
 
-    private function saveNewTag($name)
+    private function getTag($tagName)
     {
-        $this->db->table('tags')->insert(['name' => $name]);
+        return $this->db->table('tags')->where('name', $tagName)->first();
+    }
+
+    private function createTag($tagName)
+    {
+        $this->db->table('tags')->insert(['name' => $tagName]);
     }
 
     private function redirectBack(Response $response, $formData)

--- a/mubench.reviewsite/src/Controller/ReviewController.php
+++ b/mubench.reviewsite/src/Controller/ReviewController.php
@@ -67,6 +67,7 @@ class ReviewController
     function getMisuse($experimentId, Detector $detector, $projectId, $versionId, $misuseId)
     {
         $metadata = $this->metadataController->getMetadata($experimentId, $detector, $projectId, $versionId, $misuseId);
+        // REFACTOR tags should not be a field on metadata, but an independent argument to Misuse. Separate them.
         $metadata['tags'] = $this->tagsController->getTags($experimentId, $detector, $projectId, $versionId, $misuseId);
         $potential_hits = $this->getPotentialHits($experimentId, $detector, $projectId, $versionId, $misuseId);
         // SMELL misuses don't need their review here

--- a/mubench.reviewsite/src/Controller/ReviewController.php
+++ b/mubench.reviewsite/src/Controller/ReviewController.php
@@ -67,11 +67,10 @@ class ReviewController
     function getMisuse($experimentId, Detector $detector, $projectId, $versionId, $misuseId)
     {
         $metadata = $this->metadataController->getMetadata($experimentId, $detector, $projectId, $versionId, $misuseId);
-        // REFACTOR tags should not be a field on metadata, but an independent argument to Misuse. Separate them.
-        $metadata['tags'] = $this->tagsController->getTags($experimentId, $detector, $projectId, $versionId, $misuseId);
         $potential_hits = $this->getPotentialHits($experimentId, $detector, $projectId, $versionId, $misuseId);
+        $tags = $this->tagsController->getTags($experimentId, $detector, $projectId, $versionId, $misuseId);
         // SMELL misuses don't need their review here
-        return new Misuse($metadata, $potential_hits, []);
+        return new Misuse($metadata, $potential_hits, [], $tags);
     }
 
     /**

--- a/mubench.reviewsite/src/Controller/ReviewController.php
+++ b/mubench.reviewsite/src/Controller/ReviewController.php
@@ -24,14 +24,18 @@ class ReviewController
     private $renderer;
     /** @var MetadataController */
     private $metadataController;
+    /** @var MisuseTagsController */
+    private $tagsController;
 
-    function __construct($site_base_url, $upload_path, DBConnection $db, PhpRenderer $renderer, MetadataController $metadataController)
+    function __construct($site_base_url, $upload_path, DBConnection $db, PhpRenderer $renderer,
+                         MetadataController $metadataController, MisuseTagsController $tagsController)
     {
         $this->site_base_url = $site_base_url;
         $this->upload_path = $upload_path;
         $this->db = $db;
         $this->renderer = $renderer;
         $this->metadataController = $metadataController;
+        $this->tagsController = $tagsController;
     }
 
     public function get(Request $request, Response $response, array $args)
@@ -63,6 +67,7 @@ class ReviewController
     function getMisuse($experimentId, Detector $detector, $projectId, $versionId, $misuseId)
     {
         $metadata = $this->metadataController->getMetadata($experimentId, $detector, $projectId, $versionId, $misuseId);
+        $metadata['tags'] = $this->tagsController->getTags($experimentId, $detector, $projectId, $versionId, $misuseId);
         $potential_hits = $this->getPotentialHits($experimentId, $detector, $projectId, $versionId, $misuseId);
         // SMELL misuses don't need their review here
         return new Misuse($metadata, $potential_hits, []);

--- a/mubench.reviewsite/src/Controller/ReviewController.php
+++ b/mubench.reviewsite/src/Controller/ReviewController.php
@@ -67,10 +67,10 @@ class ReviewController
     function getMisuse($experimentId, Detector $detector, $projectId, $versionId, $misuseId)
     {
         $metadata = $this->metadataController->getMetadata($experimentId, $detector, $projectId, $versionId, $misuseId);
-        $potential_hits = $this->getPotentialHits($experimentId, $detector, $projectId, $versionId, $misuseId);
+        $potentialHits = $this->getPotentialHits($experimentId, $detector, $projectId, $versionId, $misuseId);
         $tags = $this->tagsController->getTags($experimentId, $detector, $projectId, $versionId, $misuseId);
         // SMELL misuses don't need their review here
-        return new Misuse($metadata, $potential_hits, [], $tags);
+        return new Misuse($metadata, $potentialHits, [], $tags);
     }
 
     /**

--- a/mubench.reviewsite/src/Controller/TagController.php
+++ b/mubench.reviewsite/src/Controller/TagController.php
@@ -34,10 +34,14 @@ class TagController
         return $this->redirectBack($response, $formData);
     }
 
-    public function getTags($experimentId, Detector $detector, $projectId, $versionId, $misuseId)
+    /**
+     * @return array
+     */
+    public function getTags($experimentId, $detectorId, $projectId, $versionId, $misuseId)
     {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->db->table('misuse_tags')->innerJoin('tags', 'misuse_tags.tag', '=', 'tags.id')
-            ->select('id', 'name')->where('exp', $experimentId)->where('detector', $detector->id)
+            ->select('id', 'name')->where('exp', $experimentId)->where('detector', $detectorId)
             ->where('project', $projectId)->where('version', $versionId)->where('misuse', $misuseId)->get();
     }
 

--- a/mubench.reviewsite/src/DBConnection.php
+++ b/mubench.reviewsite/src/DBConnection.php
@@ -298,8 +298,12 @@ class DBConnection
         return $this->table('tags')->get();
     }
 
+    /**
+     * @return array
+     */
     public function getTagsForMisuse($experiment, $detector, $project, $version, $misuse)
     {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $this->table('misuse_tags')->innerJoin('tags', 'misuse_tags.tag', '=', 'tags.id')->select('id', 'name')->where('exp', $experiment)->where('detector', $detector)
             ->where('project', $project)->where('version', $version)->where('misuse', $misuse)->get();
     }

--- a/mubench.reviewsite/src/DBConnection.php
+++ b/mubench.reviewsite/src/DBConnection.php
@@ -115,13 +115,13 @@ class DBConnection
                     $misuse["violation_types"] = $this->getViolationTypeNamesForMisuse($project_id, $version_id, $misuse_id);
                 }
                 $misuse["snippets"] = $snippets;
-                $misuse["tags"] = $this->getTagsForMisuse($exp, $detector->id, $project_id, $version_id, $misuse_id);
+                $tags = $this->getTagsForMisuse($exp, $detector->id, $project_id, $version_id, $misuse_id);
 
                 if(strcmp($exp, "ex1") == 0){
                     $patterns = $this->getPatterns($misuse_id);
                     $misuse["patterns"] = $patterns;
                 }
-                $misuses[$key] = new Misuse($misuse, $potential_hits, $reviews);
+                $misuses[$key] = new Misuse($misuse, $potential_hits, $reviews, $tags);
             }
             if($max_reviews > -1 && strcmp($exp, "ex2") == 0){
                 $misuses = $this->filterMisusesForMaxReviews($misuses, $max_reviews);
@@ -300,9 +300,11 @@ class DBConnection
 
     private function getTagsForMisuse($experiment, $detector, $project, $version, $misuse)
     {
-        return $this->table('misuse_tags')->innerJoin('tags', 'misuse_tags.tag', '=', 'tags.id')->select('id', 'name')
+        /** @var array $tags */
+        $tags = $this->table('misuse_tags')->innerJoin('tags', 'misuse_tags.tag', '=', 'tags.id')->select('id', 'name')
             ->where('exp', $experiment)->where('detector', $detector)->where('project', $project)
             ->where('version', $version)->where('misuse', $misuse)->get();
+        return $tags;
     }
 
     public function getMisuseCountForType($type_id)

--- a/mubench.reviewsite/src/DBConnection.php
+++ b/mubench.reviewsite/src/DBConnection.php
@@ -298,14 +298,11 @@ class DBConnection
         return $this->table('tags')->get();
     }
 
-    /**
-     * @return array
-     */
-    public function getTagsForMisuse($experiment, $detector, $project, $version, $misuse)
+    private function getTagsForMisuse($experiment, $detector, $project, $version, $misuse)
     {
-        /** @noinspection PhpIncompatibleReturnTypeInspection */
-        return $this->table('misuse_tags')->innerJoin('tags', 'misuse_tags.tag', '=', 'tags.id')->select('id', 'name')->where('exp', $experiment)->where('detector', $detector)
-            ->where('project', $project)->where('version', $version)->where('misuse', $misuse)->get();
+        return $this->table('misuse_tags')->innerJoin('tags', 'misuse_tags.tag', '=', 'tags.id')->select('id', 'name')
+            ->where('exp', $experiment)->where('detector', $detector)->where('project', $project)
+            ->where('version', $version)->where('misuse', $misuse)->get();
     }
 
     public function getMisuseCountForType($type_id)

--- a/mubench.reviewsite/src/Model/Misuse.php
+++ b/mubench.reviewsite/src/Model/Misuse.php
@@ -10,19 +10,25 @@ class Misuse
     private $data;
     private $potential_hits;
     private $reviews;
+    /**
+     * @var array
+     */
+    private $tags;
 
     /**
      * @param array $data
      * @param array $potential_hits
      * @param Review[] $reviews
+     * @param array $tags
      */
-    public function __construct(array $data, array $potential_hits, $reviews)
+    public function __construct(array $data, array $potential_hits, array $reviews, array $tags)
     {
         assert(array_key_exists("misuse", $data), "misuse requires id");
         $this->id = $data["misuse"];
         $this->data = $data;
         $this->potential_hits = $potential_hits;
         $this->reviews = $reviews;
+        $this->tags = $tags;
     }
 
     public function getProject()
@@ -66,12 +72,12 @@ class Misuse
 
     public function getTags()
     {
-        return $this->data['tags'];
+        return $this->tags;
     }
 
     public function hasTags()
     {
-        return !empty($this->data['tags']);
+        return !empty($this->getTags());
     }
 
     public function getFile(){

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -7,7 +7,7 @@ use MuBench\ReviewSite\Controller\ReviewController;
 use MuBench\ReviewSite\Controller\ReviewUploader;
 use MuBench\ReviewSite\Controller\SnippetUploader;
 use MuBench\ReviewSite\Controller\DownloadController;
-use MuBench\ReviewSite\Controller\TagController;
+use MuBench\ReviewSite\Controller\MisuseTagsController;
 use MuBench\ReviewSite\DBConnection;
 use MuBench\ReviewSite\DirectoryHelper;
 use MuBench\ReviewSite\Model\Experiment;
@@ -22,7 +22,7 @@ $database = $app->getContainer()['database'];
 $renderer = $app->getContainer()['renderer'];
 // REFACTOR rename RoutesHelper to ResultsViewController
 $routesHelper = new RoutesHelper($database, $renderer, $logger, $settings['upload'], $settings['site_base_url'], $settings['default_ex2_review_size']);
-$tagController = new TagController($database, $logger, $settings["site_base_url"]);
+$tagController = new MisuseTagsController($database, $logger, $settings["site_base_url"]);
 $downloadController = new DownloadController($database, $logger, $settings['default_ex2_review_size']);
 $metadataController = new MetadataController($database, $logger, $tagController);
 $reviewController = new ReviewController($settings["site_base_url"], $settings["upload"], $database, $renderer, $metadataController);

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -24,7 +24,7 @@ $renderer = $app->getContainer()['renderer'];
 $routesHelper = new RoutesHelper($database, $renderer, $logger, $settings['upload'], $settings['site_base_url'], $settings['default_ex2_review_size']);
 $tagController = new TagController($database, $logger, $settings["site_base_url"]);
 $downloadController = new DownloadController($database, $logger, $settings['default_ex2_review_size']);
-$metadataController = new MetadataController($database, $logger);
+$metadataController = new MetadataController($database, $logger, $tagController);
 $reviewController = new ReviewController($settings["site_base_url"], $settings["upload"], $database, $renderer, $metadataController);
 
 $app->get('/', [$routesHelper, 'index']);

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -109,12 +109,8 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $tagCont
             }
         });
 
-    $app->post('/delete/tag',
-        function (Request $request, Response $response, array $args) use ($database, $settings, $tagController) {
-            $obj = $request->getParsedBody();
-            $tagController->deleteMisuseTag($obj);
-            return $response->withRedirect("{$settings['site_base_url']}index.php/{$obj['path']}");
-        });
+    $app->post('/tag', [$tagController, "add"]);
+    $app->post('/delete/tag', [$tagController, 'delete']);
 
     $app->post('/snippet',
         function (Request $request, Response $response, array $args) use ($database, $settings) {
@@ -124,6 +120,5 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $tagCont
             return $response->withRedirect("{$settings['site_base_url']}index.php/{$obj['path']}");
         });
 
-    $app->post('/tag', [$tagController, "add"]);
 
 });

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -109,7 +109,9 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $tagCont
             }
         });
 
+    // REFACTOR migrate this route to /{exp}/{detector}/{project}/{version}/{misuse}/tags/{tagname}/add
     $app->post('/tag', [$tagController, "add"]);
+    // REFACTOR migrate this route to /{exp}/{detector}/{project}/{version}/{misuse}/tags/{tagname}/delete
     $app->post('/delete/tag', [$tagController, 'delete']);
 
     $app->post('/snippet',

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -22,10 +22,11 @@ $database = $app->getContainer()['database'];
 $renderer = $app->getContainer()['renderer'];
 // REFACTOR rename RoutesHelper to ResultsViewController
 $routesHelper = new RoutesHelper($database, $renderer, $logger, $settings['upload'], $settings['site_base_url'], $settings['default_ex2_review_size']);
-$tagController = new MisuseTagsController($database, $logger, $settings["site_base_url"]);
 $downloadController = new DownloadController($database, $logger, $settings['default_ex2_review_size']);
-$metadataController = new MetadataController($database, $logger, $tagController);
-$reviewController = new ReviewController($settings["site_base_url"], $settings["upload"], $database, $renderer, $metadataController);
+$metadataController = new MetadataController($database, $logger);
+$tagController = new MisuseTagsController($database, $logger, $settings["site_base_url"]);
+$reviewController = new ReviewController($settings["site_base_url"], $settings["upload"],
+    $database, $renderer, $metadataController, $tagController);
 
 $app->get('/', [$routesHelper, 'index']);
 $app->get('/{exp:ex[1-3]}/{detector}', [$routesHelper, 'detector']);
@@ -115,7 +116,7 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $tagCont
     $app->post('/tag', [$tagController, "add"]);
     // REFACTOR migrate this route to /tags/{exp}/{detector}/{project}/{version}/{misuse}/{tagname}/delete
     $app->post('/delete/tag', [$tagController, 'delete']);
-    
+
     $app->post('/snippet',
         function (Request $request, Response $response, array $args) use ($database, $settings) {
             $obj = $request->getParsedBody();

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -93,7 +93,9 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $tagCont
             return $response->withStatus(200);
         });
 
+    // REFACTOR migrate to /metadata/{project}/{version}/{misuse}/update
     $app->post('/metadata', [$metadataController, "update"]);
+    // REFACTOR migrate to /reviews/{exp}/{detector}/{project}/{version}/{misuse}/{reviewerName}/update
     $app->post('/review/{exp:ex[1-3]}/{detector}', [$reviewController, "update"]);
 
     $app->post('/delete/snippet/{exp:ex[1-3]}/{detector}',
@@ -109,11 +111,11 @@ $app->group('/api/upload', function () use ($app, $settings, $database, $tagCont
             }
         });
 
-    // REFACTOR migrate this route to /{exp}/{detector}/{project}/{version}/{misuse}/tags/{tagname}/add
+    // REFACTOR migrate this route to /tags/{exp}/{detector}/{project}/{version}/{misuse}/{tagname}/add
     $app->post('/tag', [$tagController, "add"]);
-    // REFACTOR migrate this route to /{exp}/{detector}/{project}/{version}/{misuse}/tags/{tagname}/delete
+    // REFACTOR migrate this route to /tags/{exp}/{detector}/{project}/{version}/{misuse}/{tagname}/delete
     $app->post('/delete/tag', [$tagController, 'delete']);
-
+    
     $app->post('/snippet',
         function (Request $request, Response $response, array $args) use ($database, $settings) {
             $obj = $request->getParsedBody();

--- a/mubench.reviewsite/tests/CSVHelperTest.php
+++ b/mubench.reviewsite/tests/CSVHelperTest.php
@@ -38,6 +38,7 @@ class CSVHelperTest extends TestCase
         $this->no_reviews_misuse = new Misuse(
             ["misuse" => "0"],
             [0 => []],
+            [],
             []
         );
         $this->positive_reviews_misuse = new Misuse(
@@ -53,7 +54,8 @@ class CSVHelperTest extends TestCase
                             'decision' => 'Yes',
                         ]
                     ]
-                ])]
+                ])],
+            []
         );
         $this->resolved_review_misuse = new Misuse(
             ["misuse" => "0"],
@@ -77,7 +79,8 @@ class CSVHelperTest extends TestCase
                             'decision' => 'Yes',
                         ]
                     ]
-                ])]
+                ])],
+            []
         );
     }
 

--- a/mubench.reviewsite/tests/ReviewControllerTest.php
+++ b/mubench.reviewsite/tests/ReviewControllerTest.php
@@ -24,7 +24,8 @@ class ReviewControllerTest extends DatabaseTestCase
     {
         parent::setUp();
         $this->detector = $this->db->getOrCreateDetector('-d-');
-        $metadataController = new MetadataController($this->db, $this->logger);
+        $tagController = new TagController($this->db, $this->logger, '-site-base-url-');
+        $metadataController = new MetadataController($this->db, $this->logger, $tagController);
         $renderer = new PhpRenderer();
         $this->reviewController = new ReviewController('', '', $this->db, $renderer, $metadataController);
     }

--- a/mubench.reviewsite/tests/ReviewControllerTest.php
+++ b/mubench.reviewsite/tests/ReviewControllerTest.php
@@ -24,10 +24,10 @@ class ReviewControllerTest extends DatabaseTestCase
     {
         parent::setUp();
         $this->detector = $this->db->getOrCreateDetector('-d-');
-        $tagController = new TagController($this->db, $this->logger, '-site-base-url-');
-        $metadataController = new MetadataController($this->db, $this->logger, $tagController);
+        $tagController = new MisuseTagsController($this->db, $this->logger, '-site-base-url-');
+        $metadataController = new MetadataController($this->db, $this->logger);
         $renderer = new PhpRenderer();
-        $this->reviewController = new ReviewController('', '', $this->db, $renderer, $metadataController);
+        $this->reviewController = new ReviewController('', '', $this->db, $renderer, $metadataController, $tagController);
     }
 
 
@@ -141,8 +141,7 @@ class ReviewControllerTest extends DatabaseTestCase
                     [[
                         'line' => '273',
                         'snippet' => '-code-'
-                    ]],
-                'tags' => []
+                    ]]
             ],
             [
                 [
@@ -152,7 +151,7 @@ class ReviewControllerTest extends DatabaseTestCase
                     'misuse' => '-m-',
                     'rank' => '0'
                 ]
-            ], []);
+            ], [], []);
 
         self::assertEquals($expectedMisuse, $actualMisuse);
     }
@@ -181,8 +180,7 @@ class ReviewControllerTest extends DatabaseTestCase
                 'project' => '-p-',
                 'version' => '-v-',
                 'misuse' => 0,
-                'snippets' => [],
-                'tags' => []
+                'snippets' => []
             ],
             [
                 [
@@ -192,7 +190,7 @@ class ReviewControllerTest extends DatabaseTestCase
                     'misuse' => 0,
                     'rank' => 0
                 ]
-            ], []);
+            ], [], []);
         self::assertEquals($expectedMisuse, $actualMisuse);
     }
 

--- a/mubench.reviewsite/tests/ReviewStateTest.php
+++ b/mubench.reviewsite/tests/ReviewStateTest.php
@@ -8,62 +8,49 @@ class ReviewStateTest extends \PHPUnit\Framework\TestCase
 {
     function test_no_potential_hits()
     {
-        $misuse = new Misuse(["misuse" => "test"], [], []);
+        $misuse = new Misuse(["misuse" => "test"], [], [], []);
 
         self::assertEquals(ReviewState::NOTHING_TO_REVIEW, $misuse->getReviewState());
     }
 
     function test_needs_2_reviews()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], []);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions([/* none */]);
 
         self::assertEquals(ReviewState::NEEDS_REVIEW, $misuse->getReviewState());
     }
 
     function test_needs_1_review()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "Yes"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['Yes']);
 
         self::assertEquals(ReviewState::NEEDS_REVIEW, $misuse->getReviewState());
     }
 
     function test_needs_review_overrules_needs_carification()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "?"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['?']);
 
         self::assertEquals(ReviewState::NEEDS_REVIEW, $misuse->getReviewState());
     }
 
     function test_agreement_yes()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "Yes"]]]),
-            new Review(["name" => "hoan", "finding_reviews" => ["0" => ["decision" => "Yes"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['Yes', 'Yes']);
 
         self::assertEquals(ReviewState::AGREEMENT_YES, $misuse->getReviewState());
     }
 
     function test_agreement_no()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "No"]]]),
-            new Review(["name" => "hoan", "finding_reviews" => ["0" => ["decision" => "No"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['No', 'No']);
 
         self::assertEquals(ReviewState::AGREEMENT_NO, $misuse->getReviewState());
     }
 
     function test_disagreement()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "Yes"]]]),
-            new Review(["name" => "hoan", "finding_reviews" => ["0" => ["decision" => "No"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['Yes', 'No']);
 
         self::assertEquals(ReviewState::DISAGREEMENT, $misuse->getReviewState());
     }
@@ -71,43 +58,28 @@ class ReviewStateTest extends \PHPUnit\Framework\TestCase
     function test_needs_clarification()
     {
         // NEEDS_REVIEW takes precedence over NEEDS_CLARIFICATION, hence, we need at least two reviews for this state.
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "?"]]]),
-            new Review(["name" => "hoan", "finding_reviews" => ["0" => ["decision" => "Yes"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['Yes', '?']);
 
         self::assertEquals(ReviewState::NEEDS_CLARIFICATION, $misuse->getReviewState());
     }
 
     function test_resolution_yes()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "Yes"]]]),
-            new Review(["name" => "hoan", "finding_reviews" => ["0" => ["decision" => "No"]]]),
-            new Review(["name" => "resolution", "finding_reviews" => ["0" => ["decision" => "Yes"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['Yes', 'No'], 'Yes');
 
         self::assertEquals(ReviewState::RESOLVED_YES, $misuse->getReviewState());
     }
 
     function test_resolution_no()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "Yes"]]]),
-            new Review(["name" => "hoan", "finding_reviews" => ["0" => ["decision" => "No"]]]),
-            new Review(["name" => "resolution", "finding_reviews" => ["0" => ["decision" => "No"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['Yes', 'No'], 'No');
 
         self::assertEquals(ReviewState::RESOLVED_NO, $misuse->getReviewState());
     }
 
     function test_resolution_unresolved()
     {
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "Yes"]]]),
-            new Review(["name" => "hoan", "finding_reviews" => ["0" => ["decision" => "No"]]]),
-            new Review(["name" => "resolution", "finding_reviews" => ["0" => ["decision" => "?"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['Yes', 'No'], '?');
 
         self::assertEquals(ReviewState::UNRESOLVED, $misuse->getReviewState());
     }
@@ -115,12 +87,30 @@ class ReviewStateTest extends \PHPUnit\Framework\TestCase
     function test_resolution_is_absolute()
     {
         // Resolution determines the result, even if there are too few reviews and requests for clarification.
-        $misuse = new Misuse(["misuse" => "test"], [["rank" => "0"]], [
-            new Review(["name" => "sven", "finding_reviews" => ["0" => ["decision" => "?"]]]),
-            new Review(["name" => "hoan", "finding_reviews" => ["0" => ["decision" => "Yes"]]]),
-            new Review(["name" => "resolution", "finding_reviews" => ["0" => ["decision" => "No"]]])
-        ]);
+        $misuse = $this->someMisuseWithOneFindingAndReviewDecisions(['?', 'Yes'], 'No');
 
         self::assertEquals(ReviewState::RESOLVED_NO, $misuse->getReviewState());
+    }
+
+    private function someMisuseWithOneFindingAndReviewDecisions($decisions, $resolutionDecision = null)
+    {
+        $findingRank = '0';
+
+        $reviews = [];
+        foreach ($decisions as $index => $decision) {
+            $reviews[] = new Review([
+                'name' => 'reviewer_' . $index,
+                'finding_reviews' => [$findingRank => ['decision' => $decision]]
+            ]);
+        }
+
+        if ($resolutionDecision) {
+            $reviews[] = new Review([
+                'name' => 'resolution',
+                'finding_reviews' => [$findingRank => ['decision' => $resolutionDecision]]
+            ]);
+        }
+
+        return new Misuse(['misuse' => 'test'], [['rank' => $findingRank]], $reviews, []);
     }
 }

--- a/mubench.reviewsite/tests/StoreFindingsTest.php
+++ b/mubench.reviewsite/tests/StoreFindingsTest.php
@@ -137,8 +137,7 @@ class StoreFindingsTest extends DatabaseTestCase
     }
 
     function test_get_misuse_ex1(){
-        $tagController = new MisuseTagsController($this->db, $this->logger, '-site-base-url');
-        $metadataController = new MetadataController($this->db, $this->logger, $tagController);
+        $metadataController = new MetadataController($this->db, $this->logger);
         // SMELL currently, this test depends on a pattern in the metadata, because otherwise the metadata is not
         // found for ex1. This should not be necessary anymore, once the findings controller is separated.
         $metadataController->updateMetadata('-p-', '-v-', '-m-', '-desc-',

--- a/mubench.reviewsite/tests/StoreFindingsTest.php
+++ b/mubench.reviewsite/tests/StoreFindingsTest.php
@@ -78,7 +78,7 @@ class StoreFindingsTest extends DatabaseTestCase
             "number_of_findings" => "23",
             "misuses" => [
                 new Misuse(
-                    ["misuse" => "0", "snippets" => [0 => ["line" => "5", "snippet" => "-code-", "id" => "1"]], "tags" => []],
+                    ["misuse" => "0", "snippets" => [0 => ["line" => "5", "snippet" => "-code-", "id" => "1"]]],
                     [0 => [
                         "exp" => "ex2",
                         "project" => "-p-",
@@ -89,6 +89,7 @@ class StoreFindingsTest extends DatabaseTestCase
                         "custom2" => "-val2-"
                     ]
                     ],
+                    [],
                     []
                 )
             ],
@@ -186,8 +187,7 @@ EOT
                 'snippets' => [],
                 'patterns' => [
                     ['name' => '-p1-', 'code' => '-code-', 'line' => 42]
-                ],
-                'tags' => []
+                ]
             ],
             [[
                 'exp' => 'ex1',
@@ -198,7 +198,9 @@ EOT
                 'custom1' => '-val1-',
                 'custom2' => '-val2-',
             ]],
-            []);
+            [],
+            []
+        );
 
         self::assertEquals($expected_misuse, $misuse);
     }

--- a/mubench.reviewsite/tests/StoreFindingsTest.php
+++ b/mubench.reviewsite/tests/StoreFindingsTest.php
@@ -5,7 +5,7 @@ require_once "DatabaseTestCase.php";
 use MuBench\ReviewSite\Controller\FindingsUploader;
 use MuBench\ReviewSite\Controller\MetadataController;
 use MuBench\ReviewSite\Controller\SnippetUploader;
-use MuBench\ReviewSite\Controller\TagController;
+use MuBench\ReviewSite\Controller\MisuseTagsController;
 use MuBench\ReviewSite\Model\Misuse;
 
 class StoreFindingsTest extends DatabaseTestCase
@@ -137,7 +137,7 @@ class StoreFindingsTest extends DatabaseTestCase
     }
 
     function test_get_misuse_ex1(){
-        $tagController = new TagController($this->db, $this->logger, '-site-base-url');
+        $tagController = new MisuseTagsController($this->db, $this->logger, '-site-base-url');
         $metadataController = new MetadataController($this->db, $this->logger, $tagController);
         // SMELL currently, this test depends on a pattern in the metadata, because otherwise the metadata is not
         // found for ex1. This should not be necessary anymore, once the findings controller is separated.

--- a/mubench.reviewsite/tests/StoreFindingsTest.php
+++ b/mubench.reviewsite/tests/StoreFindingsTest.php
@@ -5,6 +5,7 @@ require_once "DatabaseTestCase.php";
 use MuBench\ReviewSite\Controller\FindingsUploader;
 use MuBench\ReviewSite\Controller\MetadataController;
 use MuBench\ReviewSite\Controller\SnippetUploader;
+use MuBench\ReviewSite\Controller\TagController;
 use MuBench\ReviewSite\Model\Misuse;
 
 class StoreFindingsTest extends DatabaseTestCase
@@ -136,7 +137,8 @@ class StoreFindingsTest extends DatabaseTestCase
     }
 
     function test_get_misuse_ex1(){
-        $metadataController = new MetadataController($this->db, $this->logger);
+        $tagController = new TagController($this->db, $this->logger, '-site-base-url');
+        $metadataController = new MetadataController($this->db, $this->logger, $tagController);
         // SMELL currently, this test depends on a pattern in the metadata, because otherwise the metadata is not
         // found for ex1. This should not be necessary anymore, once the findings controller is separated.
         $metadataController->updateMetadata('-p-', '-v-', '-m-', '-desc-',

--- a/mubench.reviewsite/tests/StoreMetadataTest.php
+++ b/mubench.reviewsite/tests/StoreMetadataTest.php
@@ -18,7 +18,7 @@ class StoreMetadataTest extends DatabaseTestCase
     {
         parent::setUp();
         $this->detector = $this->db->getOrCreateDetector('-d-');
-        $tagController = new TagController($this->db, $this->logger, '-site-base-url');
+        $tagController = new MisuseTagsController($this->db, $this->logger, '-site-base-url');
         $this->metadataController = new MetadataController($this->db, $this->logger, $tagController);
     }
 

--- a/mubench.reviewsite/tests/StoreMetadataTest.php
+++ b/mubench.reviewsite/tests/StoreMetadataTest.php
@@ -18,8 +18,7 @@ class StoreMetadataTest extends DatabaseTestCase
     {
         parent::setUp();
         $this->detector = $this->db->getOrCreateDetector('-d-');
-        $tagController = new MisuseTagsController($this->db, $this->logger, '-site-base-url');
-        $this->metadataController = new MetadataController($this->db, $this->logger, $tagController);
+        $this->metadataController = new MetadataController($this->db, $this->logger);
     }
 
     function test_store_metadata()
@@ -45,8 +44,7 @@ class StoreMetadataTest extends DatabaseTestCase
             'method' => '-method-location-',
             'diff_url' => '-diff-',
             'snippets' => [0 => ['snippet' => '-target-snippet-code-', 'line' => 273]],
-            'patterns' => [0 => ['name' => '-p1-', 'code' => '-pattern-code-','line' => 42]],
-            'tags' => []
+            'patterns' => [0 => ['name' => '-p1-', 'code' => '-pattern-code-','line' => 42]]
         ], $metadata);
     }
 
@@ -58,8 +56,7 @@ class StoreMetadataTest extends DatabaseTestCase
             'project' => '-p-',
             'version' => '-v-',
             'misuse' => '-m-',
-            'snippets' => [],
-            'tags' => []
+            'snippets' => []
         ], $metadata);
     }
 

--- a/mubench.reviewsite/tests/StoreMetadataTest.php
+++ b/mubench.reviewsite/tests/StoreMetadataTest.php
@@ -5,22 +5,33 @@ namespace MuBench\ReviewSite\Controller;
 require_once "DatabaseTestCase.php";
 
 use DatabaseTestCase;
+use MuBench\ReviewSite\Model\Detector;
 
 class StoreMetadataTest extends DatabaseTestCase
 {
+    /** @var MetadataController */
+    private $metadataController;
+    /** @var Detector */
+    private $detector;
+
+    function setUp()
+    {
+        parent::setUp();
+        $this->detector = $this->db->getOrCreateDetector('-d-');
+        $tagController = new TagController($this->db, $this->logger, '-site-base-url');
+        $this->metadataController = new MetadataController($this->db, $this->logger, $tagController);
+    }
+
     function test_store_metadata()
     {
-        $detector = $this->db->getOrCreateDetector('-d-');
-        $metadataController = new MetadataController($this->db, $this->logger);
-
-        $metadataController->updateMetadata('-p-', '-v-', '-m-', '-desc-',
+        $this->metadataController->updateMetadata('-p-', '-v-', '-m-', '-desc-',
             ['diff-url' => '-diff-', 'description' => '-fix-desc-'],
             ['file' => '-file-location-', 'method' => '-method-location-'],
             ['missing/call'],
             [['id' => '-p1-', 'snippet' => ['code' => '-pattern-code-', 'first_line' => 42]]],
             [['code' => '-target-snippet-code-', 'first_line_number' => 273]]);
 
-        $metadata = $metadataController->getMetadata('ex1', $detector, '-p-', '-v-', '-m-');
+        $metadata = $this->metadataController->getMetadata('ex1', $this->detector, '-p-', '-v-', '-m-');
 
         self::assertEquals([
             'project' => '-p-',
@@ -41,10 +52,7 @@ class StoreMetadataTest extends DatabaseTestCase
 
     function test_e2_metadata()
     {
-        $detector = $this->db->getOrCreateDetector('-d-');
-        $metadataController = new MetadataController($this->db, $this->logger);
-
-        $metadata = $metadataController->getMetadata('ex2', $detector, '-p-', '-v-', '-m-');
+        $metadata = $this->metadataController->getMetadata('ex2', $this->detector, '-p-', '-v-', '-m-');
 
         self::assertEquals([
             'project' => '-p-',

--- a/mubench.reviewsite/tests/TagMisusesTest.php
+++ b/mubench.reviewsite/tests/TagMisusesTest.php
@@ -5,7 +5,7 @@ namespace MuBench\ReviewSite\Controller;
 use DatabaseTestCase;
 use MuBench\ReviewSite\Model\Detector;
 
-class TagTest extends DatabaseTestCase
+class TagMisusesTest extends DatabaseTestCase
 {
     /** @var MisuseTagsController */
     private $tagController;

--- a/mubench.reviewsite/tests/TagsTest.php
+++ b/mubench.reviewsite/tests/TagsTest.php
@@ -44,14 +44,7 @@ class TagTest extends DatabaseTestCase
         $this->db->table('tags')->insert(['name' => 'test1']);
         $this->tagController->addTag('ex1', $this->detector, '-project-', '-version-', '-misuse-', 'test1');
 
-        $this->tagController->deleteMisuseTag([
-            "tag" => 1,
-            "exp" => 'ex1',
-            "detector" => 1,
-            "project" => "-project-",
-            "version" => "-version-",
-            "misuse" => "-misuse-"
-        ]);
+        $this->tagController->deleteTag('ex1', $this->detector, '-project-', '-version-', '-misuse-', 'test1');
 
         $misuseTags = $this->tagController->getTags('ex1', $this->detector, "-project-", "-version-", "-misuse-");
         self::assertEquals([], $misuseTags);

--- a/mubench.reviewsite/tests/TagsTest.php
+++ b/mubench.reviewsite/tests/TagsTest.php
@@ -7,7 +7,7 @@ use MuBench\ReviewSite\Model\Detector;
 
 class TagTest extends DatabaseTestCase
 {
-    /** @var TagController */
+    /** @var MisuseTagsController */
     private $tagController;
 
     /** @var Detector */
@@ -16,7 +16,7 @@ class TagTest extends DatabaseTestCase
     function setUp()
     {
         parent::setUp();
-        $this->tagController = new TagController($this->db, $this->logger, "-site-base-url-");
+        $this->tagController = new MisuseTagsController($this->db, $this->logger, "-site-base-url-");
         $this->detector = $this->db->getOrCreateDetector('-d-');
     }
 

--- a/mubench.reviewsite/tests/TagsTest.php
+++ b/mubench.reviewsite/tests/TagsTest.php
@@ -1,18 +1,18 @@
 <?php
 
-require_once "DatabaseTestCase.php";
+namespace MuBench\ReviewSite\Controller;
 
-use MuBench\ReviewSite\Controller\TagController;
+use DatabaseTestCase;
 
 class TagTest extends DatabaseTestCase
 {
-
+    /** @var TagController */
     private $tagController;
 
     function setUp()
     {
         parent::setUp();
-        $this->tagController = new TagController($this->db, $this->logger);
+        $this->tagController = new TagController($this->db, $this->logger, "-site-base-url-");
     }
 
     function test_get_all_tags()
@@ -28,86 +28,46 @@ class TagTest extends DatabaseTestCase
     function test_save_misuse_tags()
     {
         $this->db->table('tags')->insert(['name' => 'test1']);
-        $misuse_tag1 = [
-            "tag" => 'test1',
-            "exp" => 1,
-            "detector" => 1,
-            "project" => "-project-",
-            "version" => "-version-",
-            "misuse" => "-misuse-"
-        ];
-        $this->tagController->saveTagForMisuse($misuse_tag1);
-        $expected_tags = [
-            ['id' => 1, 'name' => 'test1']
-        ];
-        $misuse_tags = $this->db->getTagsForMisuse(1, 1, "-project-", "-version-", "-misuse-");
+        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
+        $misuseTags = $this->db->getTagsForMisuse('ex1', 1, "-project-", "-version-", "-misuse-");
 
-        self::assertEquals($expected_tags, $misuse_tags);
+        self::assertEquals([['id' => 1, 'name' => 'test1']], $misuseTags);
     }
 
     function test_delete_misuse_tag()
     {
         $this->db->table('tags')->insert(['name' => 'test1']);
-        $misuse_tag1 = [
-            "tag" => 'test1',
-            "exp" => 1,
-            "detector" => 1,
-            "project" => "-project-",
-            "version" => "-version-",
-            "misuse" => "-misuse-"
-        ];
-        $remove_tag = [
-            "tag" => 1,
-            "exp" => 1,
-            "detector" => 1,
-            "project" => "-project-",
-            "version" => "-version-",
-            "misuse" => "-misuse-"
-        ];
-        $this->tagController->saveTagForMisuse($misuse_tag1);
-        $this->tagController->deleteMisuseTag($remove_tag);
-        $misuse_tags = $this->db->getTagsForMisuse(1, 1, "-project-", "-version-", "-misuse-");
+        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
 
-        self::assertEquals([], $misuse_tags);
+        $this->tagController->deleteMisuseTag([
+            "tag" => 1,
+            "exp" => 'ex1',
+            "detector" => 1,
+            "project" => "-project-",
+            "version" => "-version-",
+            "misuse" => "-misuse-"
+        ]);
+
+        $misuseTags = $this->db->getTagsForMisuse('ex1', 1, "-project-", "-version-", "-misuse-");
+        self::assertEquals([], $misuseTags);
     }
 
     function test_adding_same_tag_twice()
     {
         $this->db->table('tags')->insert(['name' => 'test1']);
-        $misuse_tag1 = [
-            "tag" => 'test1',
-            "exp" => 1,
-            "detector" => 1,
-            "project" => "-project-",
-            "version" => "-version-",
-            "misuse" => "-misuse-"
-        ];
-        $expected_tags = [
-            ['id' => 1, 'name' => 'test1']
-        ];
-        $this->tagController->saveTagForMisuse($misuse_tag1);
-        $this->tagController->saveTagForMisuse($misuse_tag1);
-        $misuse_tags = $this->db->getTagsForMisuse(1, 1, "-project-", "-version-", "-misuse-");
+        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
 
-        self::assertEquals($expected_tags, $misuse_tags);
+        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
+
+        $misuseTags = $this->db->getTagsForMisuse('ex1', 1, "-project-", "-version-", "-misuse-");
+        self::assertEquals(1, count($misuseTags));
     }
 
     function test_add_unknown_tag()
     {
-        $misuse_tag1 = [
-            "tag" => 'unknown_tag',
-            "exp" => 1,
-            "detector" => 1,
-            "project" => "-project-",
-            "version" => "-version-",
-            "misuse" => "-misuse-"
-        ];
-        $expected_tags = [
-            ['id' => 1, 'name' => 'unknown_tag']
-        ];
-        $this->tagController->saveTagForMisuse($misuse_tag1);
-        $misuse_tags = $this->db->getTagsForMisuse(1, 1, "-project-", "-version-", "-misuse-");
+        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'unknown_tag');
 
-        self::assertEquals($expected_tags, $misuse_tags);
+        $misuse_tags = $this->db->getTagsForMisuse('ex1', 1, "-project-", "-version-", "-misuse-");
+        self::assertEquals([['id' => 1, 'name' => 'unknown_tag']], $misuse_tags);
     }
 }

--- a/mubench.reviewsite/tests/TagsTest.php
+++ b/mubench.reviewsite/tests/TagsTest.php
@@ -29,8 +29,8 @@ class TagTest extends DatabaseTestCase
     {
         $this->db->table('tags')->insert(['name' => 'test1']);
         $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
-        $misuseTags = $this->db->getTagsForMisuse('ex1', 1, "-project-", "-version-", "-misuse-");
 
+        $misuseTags = $this->tagController->getTags('ex1', 1, "-project-", "-version-", "-misuse-");
         self::assertEquals([['id' => 1, 'name' => 'test1']], $misuseTags);
     }
 
@@ -48,7 +48,7 @@ class TagTest extends DatabaseTestCase
             "misuse" => "-misuse-"
         ]);
 
-        $misuseTags = $this->db->getTagsForMisuse('ex1', 1, "-project-", "-version-", "-misuse-");
+        $misuseTags = $this->tagController->getTags('ex1', 1, "-project-", "-version-", "-misuse-");
         self::assertEquals([], $misuseTags);
     }
 
@@ -59,7 +59,7 @@ class TagTest extends DatabaseTestCase
 
         $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
 
-        $misuseTags = $this->db->getTagsForMisuse('ex1', 1, "-project-", "-version-", "-misuse-");
+        $misuseTags = $this->tagController->getTags('ex1', 1, "-project-", "-version-", "-misuse-");
         self::assertEquals(1, count($misuseTags));
     }
 
@@ -67,7 +67,7 @@ class TagTest extends DatabaseTestCase
     {
         $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'unknown_tag');
 
-        $misuse_tags = $this->db->getTagsForMisuse('ex1', 1, "-project-", "-version-", "-misuse-");
+        $misuse_tags = $this->tagController->getTags('ex1', 1, "-project-", "-version-", "-misuse-");
         self::assertEquals([['id' => 1, 'name' => 'unknown_tag']], $misuse_tags);
     }
 }

--- a/mubench.reviewsite/tests/TagsTest.php
+++ b/mubench.reviewsite/tests/TagsTest.php
@@ -3,16 +3,21 @@
 namespace MuBench\ReviewSite\Controller;
 
 use DatabaseTestCase;
+use MuBench\ReviewSite\Model\Detector;
 
 class TagTest extends DatabaseTestCase
 {
     /** @var TagController */
     private $tagController;
 
+    /** @var Detector */
+    private $detector;
+
     function setUp()
     {
         parent::setUp();
         $this->tagController = new TagController($this->db, $this->logger, "-site-base-url-");
+        $this->detector = $this->db->getOrCreateDetector('-d-');
     }
 
     function test_get_all_tags()
@@ -28,16 +33,16 @@ class TagTest extends DatabaseTestCase
     function test_save_misuse_tags()
     {
         $this->db->table('tags')->insert(['name' => 'test1']);
-        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
+        $this->tagController->addTag('ex1', $this->detector, '-project-', '-version-', '-misuse-', 'test1');
 
-        $misuseTags = $this->tagController->getTags('ex1', 1, "-project-", "-version-", "-misuse-");
+        $misuseTags = $this->tagController->getTags('ex1', $this->detector, "-project-", "-version-", "-misuse-");
         self::assertEquals([['id' => 1, 'name' => 'test1']], $misuseTags);
     }
 
     function test_delete_misuse_tag()
     {
         $this->db->table('tags')->insert(['name' => 'test1']);
-        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
+        $this->tagController->addTag('ex1', $this->detector, '-project-', '-version-', '-misuse-', 'test1');
 
         $this->tagController->deleteMisuseTag([
             "tag" => 1,
@@ -48,26 +53,26 @@ class TagTest extends DatabaseTestCase
             "misuse" => "-misuse-"
         ]);
 
-        $misuseTags = $this->tagController->getTags('ex1', 1, "-project-", "-version-", "-misuse-");
+        $misuseTags = $this->tagController->getTags('ex1', $this->detector, "-project-", "-version-", "-misuse-");
         self::assertEquals([], $misuseTags);
     }
 
     function test_adding_same_tag_twice()
     {
         $this->db->table('tags')->insert(['name' => 'test1']);
-        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
+        $this->tagController->addTag('ex1', $this->detector, '-project-', '-version-', '-misuse-', 'test1');
 
-        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'test1');
+        $this->tagController->addTag('ex1', $this->detector, '-project-', '-version-', '-misuse-', 'test1');
 
-        $misuseTags = $this->tagController->getTags('ex1', 1, "-project-", "-version-", "-misuse-");
+        $misuseTags = $this->tagController->getTags('ex1', $this->detector, "-project-", "-version-", "-misuse-");
         self::assertEquals(1, count($misuseTags));
     }
 
     function test_add_unknown_tag()
     {
-        $this->tagController->addTag('ex1', 1, '-project-', '-version-', '-misuse-', 'unknown_tag');
+        $this->tagController->addTag('ex1', $this->detector, '-project-', '-version-', '-misuse-', 'unknown_tag');
 
-        $misuse_tags = $this->tagController->getTags('ex1', 1, "-project-", "-version-", "-misuse-");
+        $misuse_tags = $this->tagController->getTags('ex1', $this->detector, "-project-", "-version-", "-misuse-");
         self::assertEquals([['id' => 1, 'name' => 'unknown_tag']], $misuse_tags);
     }
 }


### PR DESCRIPTION
I pulled all the logic to handle misuse tags into one controller. I like the direction this is going. Pleas have a look if you agree. This is based on #120, so please start your review there. I again tried to commit frequently, so you can follow my progress.