### PR TITLE
Allow defaults in src and classes paths

### DIFF
--- a/data/aclang/versions/587/version.yml
+++ b/data/aclang/versions/587/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: target/classes/
+  classes: $mvn.default.classes
   commands:
   - mvn compile
   src: src/java/

--- a/data/acmath/versions/998/version.yml
+++ b/data/acmath/versions/998/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: target/classes/
+  classes: $mvn.default.classes
   commands:
   - mvn compile
   src: src/main/java/

--- a/data/adempiere/versions/1312/version.yml
+++ b/data/adempiere/versions/1312/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/alibaba-druid/versions/e10f28/version.yml
+++ b/data/alibaba-druid/versions/e10f28/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: target/classes/
+  classes: $mvn.default.classes
   commands:
   - sed -i 's#code.alibabatech.com/mvn/releases/#www.st.informatik.tu-darmstadt.de/artifacts/mubench/mvn/#g'
     pom.xml

--- a/data/androiduil/versions/660/version.yml
+++ b/data/androiduil/versions/660/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: library/target/classes/
+  classes: library/$mvn.default.classes
   src: library/src/
 misuses:
 - '1'

--- a/data/httpclient/versions/302/version.yml
+++ b/data/httpclient/versions/302/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: target/classes/
+  classes: $mvn.default.classes
   commands:
   - sed -i 's/<javac/<javac encoding="iso-8859-1"/g' build.xml
   - ant compile

--- a/data/httpclient/versions/444/version.yml
+++ b/data/httpclient/versions/444/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: target/classes/
+  classes: $mvn.default.classes
   commands:
   - sed -i 's/<javac/<javac encoding="iso-8859-1"/g' build.xml
   - sed -i 's/<property name="compile.debug"           value="false"/<property name="compile.debug" value="true"/g' build.xml

--- a/data/httpclient/versions/452/version.yml
+++ b/data/httpclient/versions/452/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: target/classes/
+  classes: $mvn.default.classes
   commands:
   - sed -i 's/<javac/<javac encoding="iso-8859-1"/g' build.xml
   - sed -i 's/<property name="compile.debug"           value="false"/<property name="compile.debug" value="true"/g' build.xml

--- a/data/itext/versions/5091/version.yml
+++ b/data/itext/versions/5091/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: target/classes/
+  classes: $mvn.default.classes
   commands:
   - mvn compile
   src: src/main/java/

--- a/data/jackrabbit/versions/1601/version.yml
+++ b/data/jackrabbit/versions/1601/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-core/target/classes/
+  classes: jackrabbit-core/$mvn.default.classes
   commands:
   - mvn compile
   src: jackrabbit-core/src/main/java/

--- a/data/jackrabbit/versions/1678/version.yml
+++ b/data/jackrabbit/versions/1678/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-jcr-server/target/classes/
+  classes: jackrabbit-jcr-server/$mvn.default.classes
   commands:
   - mvn compile
   src: jackrabbit-jcr-server/src/main/java/

--- a/data/jackrabbit/versions/1694/version.yml
+++ b/data/jackrabbit/versions/1694/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-core/target/classes/
+  classes: jackrabbit-core/$mvn.default.classes
   commands:
   - sed -i '137,143 d' jackrabbit-spi2jcr/pom.xml
   - sed -i '93,99 d' jackrabbit-spi2jcr/pom.xml

--- a/data/jackrabbit/versions/1750/version.yml
+++ b/data/jackrabbit/versions/1750/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-spi-commons/target/classes/
+  classes: jackrabbit-spi-commons/$mvn.default.classes
   commands:
   - sed -i '137,143 d' jackrabbit-spi2jcr/pom.xml
   - sed -i '93,99 d' jackrabbit-spi2jcr/pom.xml

--- a/data/jackrabbit/versions/2385/version.yml
+++ b/data/jackrabbit/versions/2385/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-jcr-server/target/classes/
+  classes: jackrabbit-jcr-server/$mvn.default.classes
   commands:
   - mvn compile -Dmaven.compiler.failOnError=false
   src: jackrabbit-jcr-server/src/main/java/

--- a/data/jackrabbit/versions/2580/version.yml
+++ b/data/jackrabbit/versions/2580/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-core/target/classes/
+  classes: jackrabbit-core/$mvn.default.classes
   commands:
   - mvn compile -Dmaven.compiler.failOnError=false
   src: jackrabbit-core/src/main/java/

--- a/data/jackrabbit/versions/2681/version.yml
+++ b/data/jackrabbit/versions/2681/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-core/target/classes/
+  classes: jackrabbit-core/$mvn.default.classes
   commands:
   - mvn compile -Dmaven.compiler.failOnError=false
   src: jackrabbit-core/src/main/java/

--- a/data/jackrabbit/versions/2984/version.yml
+++ b/data/jackrabbit/versions/2984/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-jcr2spi/target/classes/
+  classes: jackrabbit-jcr2spi/$mvn.default.classes
   commands:
   - mvn compile -Dmaven.compiler.failOnError=false
   src: jackrabbit-jcr2spi/src/main/java/

--- a/data/jackrabbit/versions/3050/version.yml
+++ b/data/jackrabbit/versions/3050/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-jcr2spi/target/classes/
+  classes: jackrabbit-jcr2spi/$mvn.default.classes
   commands:
   - mvn compile -Dmaven.compiler.failOnError=fals
   src: jackrabbit-jcr2spi/src/main/java/

--- a/data/jackrabbit/versions/3189/version.yml
+++ b/data/jackrabbit/versions/3189/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: jackrabbit-jca/target/classes/
+  classes: jackrabbit-jca/$mvn.default.classes
   commands:
   - mvn compile -Dmaven.compiler.failOnError=false
   src: jackrabbit-jca/src/main/java/

--- a/data/jfreechart/versions/1025/version.yml
+++ b/data/jfreechart/versions/1025/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: source/

--- a/data/jfreechart/versions/103/version.yml
+++ b/data/jfreechart/versions/103/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: source/

--- a/data/jfreechart/versions/164/version.yml
+++ b/data/jfreechart/versions/164/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: source/

--- a/data/jfreechart/versions/2183/version.yml
+++ b/data/jfreechart/versions/2183/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: source/

--- a/data/jfreechart/versions/2266/version.yml
+++ b/data/jfreechart/versions/2266/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: source/

--- a/data/jfreechart/versions/881/version.yml
+++ b/data/jfreechart/versions/881/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: source/

--- a/data/jmrtd/versions/51/version.yml
+++ b/data/jmrtd/versions/51/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/jmrtd/versions/67/version.yml
+++ b/data/jmrtd/versions/67/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/jodatime/versions/1231/version.yml
+++ b/data/jodatime/versions/1231/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: JodaTimeContrib/hibernate/build/classes/java/main/
+  classes: JodaTimeContrib/hibernate/$gradle.default.classes
   commands:
   - gradle :compileJava -p ./JodaTimeContrib/hibernate/
   src: JodaTimeContrib/hibernate/src/java/

--- a/data/lucene/versions/1251/version.yml
+++ b/data/lucene/versions/1251/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/java/

--- a/data/lucene/versions/1918/version.yml
+++ b/data/lucene/versions/1918/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/java/

--- a/data/lucene/versions/207/version.yml
+++ b/data/lucene/versions/207/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/java/

--- a/data/lucene/versions/754/version.yml
+++ b/data/lucene/versions/754/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/java/

--- a/data/rhino/versions/286251/version.yml
+++ b/data/rhino/versions/286251/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/alreadyondte/version.yml
+++ b/data/synthetic/versions/alreadyondte/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/callondte/version.yml
+++ b/data/synthetic/versions/callondte/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/close-1/version.yml
+++ b/data/synthetic/versions/close-1/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/close-2/version.yml
+++ b/data/synthetic/versions/close-2/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/cme/version.yml
+++ b/data/synthetic/versions/cme/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/deadlock/version.yml
+++ b/data/synthetic/versions/deadlock/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/fisexists/version.yml
+++ b/data/synthetic/versions/fisexists/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/flip-1/version.yml
+++ b/data/synthetic/versions/flip-1/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/flip-2/version.yml
+++ b/data/synthetic/versions/flip-2/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/flush/version.yml
+++ b/data/synthetic/versions/flush/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/hasnext/version.yml
+++ b/data/synthetic/versions/hasnext/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/latenullcheck/version.yml
+++ b/data/synthetic/versions/latenullcheck/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/listget/version.yml
+++ b/data/synthetic/versions/listget/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/mapkeynull/version.yml
+++ b/data/synthetic/versions/mapkeynull/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/mapnull/version.yml
+++ b/data/synthetic/versions/mapnull/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/maybenull/version.yml
+++ b/data/synthetic/versions/maybenull/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/nofile/version.yml
+++ b/data/synthetic/versions/nofile/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/pack-1/version.yml
+++ b/data/synthetic/versions/pack-1/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/pack-2/version.yml
+++ b/data/synthetic/versions/pack-2/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/repetitive/version.yml
+++ b/data/synthetic/versions/repetitive/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/setfirst/version.yml
+++ b/data/synthetic/versions/setfirst/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/supresserror/version.yml
+++ b/data/synthetic/versions/supresserror/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/toorestricitve/version.yml
+++ b/data/synthetic/versions/toorestricitve/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/unsynchronized/version.yml
+++ b/data/synthetic/versions/unsynchronized/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/data/synthetic/versions/wait-loop/version.yml
+++ b/data/synthetic/versions/wait-loop/version.yml
@@ -1,5 +1,5 @@
 build:
-  classes: build/classes/java/main/
+  classes: $gradle.default.classes
   commands:
   - gradle :compileJava
   src: src/

--- a/mubench.pipeline/data/project_version.py
+++ b/mubench.pipeline/data/project_version.py
@@ -14,6 +14,15 @@ from data.project_compile import ProjectCompile
 class ProjectVersion:
     VERSION_FILE = 'version.yml'
 
+    VARS_SRC = {
+                '$gradle.default.src': "src/main/java",
+                '$mvn.default.src': "src/main/java"
+            }
+    VARS_CLASSES = {
+                '$gradle.default.classes': "build/classes/java/main/",
+                '$mvn.default.classes': "target/classes/"
+            }
+
     def __init__(self, base_path: str, project_id: str, version_id: str):
         self._base_path = base_path
         self.version_id = version_id
@@ -64,6 +73,13 @@ class ProjectVersion:
     def __compile_config(self):
         compile = {"src": "", "commands": [], "classes": ""}
         compile.update(self._yaml.get("build", {}))
+
+        for key, value in self.VARS_SRC.items():
+            compile["src"] = compile["src"].replace(key, value)
+
+        for key, value in self.VARS_CLASSES.items():
+            compile["classes"] = compile["classes"].replace(key, value)
+
         return compile
 
     @property

--- a/mubench.pipeline/data/project_version.py
+++ b/mubench.pipeline/data/project_version.py
@@ -14,10 +14,6 @@ from data.project_compile import ProjectCompile
 class ProjectVersion:
     VERSION_FILE = 'version.yml'
 
-    VARS_SRC = {
-                '$gradle.default.src': "src/main/java",
-                '$mvn.default.src': "src/main/java"
-            }
     VARS_CLASSES = {
                 '$gradle.default.classes': "build/classes/java/main/",
                 '$mvn.default.classes': "target/classes/"
@@ -73,9 +69,6 @@ class ProjectVersion:
     def __compile_config(self):
         compile = {"src": "", "commands": [], "classes": ""}
         compile.update(self._yaml.get("build", {}))
-
-        for key, value in self.VARS_SRC.items():
-            compile["src"] = compile["src"].replace(key, value)
 
         for key, value in self.VARS_CLASSES.items():
             compile["classes"] = compile["classes"].replace(key, value)

--- a/mubench.pipeline/tests/data/test_project_version.py
+++ b/mubench.pipeline/tests/data/test_project_version.py
@@ -76,11 +76,7 @@ class TestProjectVersion:
         assert_equals(["mvn compile"], self.uut.compile_commands)
         assert_equals("target/classes/", self.uut.classes_dir)
 
-    def test_replaces_src_variables_in_build_config(self):
-        self.uut._YAML = {"build": {"src": "$mvn.default.src"}}
-        assert_equals("src/main/java/", self.uut.source_dir)
-
-    def test_replaces_src_variables_in_build_config(self):
+    def test_replaces_classes_variables_in_build_config(self):
         self.uut._YAML = {"build": {"classes": "$gradle.default.classes"}}
         assert_equals("build/classes/java/main/", self.uut.classes_dir)
 

--- a/mubench.pipeline/tests/data/test_project_version.py
+++ b/mubench.pipeline/tests/data/test_project_version.py
@@ -76,6 +76,14 @@ class TestProjectVersion:
         assert_equals(["mvn compile"], self.uut.compile_commands)
         assert_equals("target/classes/", self.uut.classes_dir)
 
+    def test_replaces_src_variables_in_build_config(self):
+        self.uut._YAML = {"build": {"src": "$mvn.default.src"}}
+        assert_equals("src/main/java/", self.uut.source_dir)
+
+    def test_replaces_src_variables_in_build_config(self):
+        self.uut._YAML = {"build": {"classes": "$gradle.default.classes"}}
+        assert_equals("build/classes/java/main/", self.uut.classes_dir)
+
     def test_creates_build_config_with_defaults(self):
         self.uut._YAML = {"-no-build-key-": ""}
         assert_equals("", self.uut.source_dir)


### PR DESCRIPTION
Implementation for #96.

We can now add key-value pairs in [project_version.py](https://github.com/stg-tud/MUBench/blob/91e326923558ae10219dd264841264ea2df73ed6/mubench.pipeline/data/project_version.py). The keys can be used in the `project.yml` for `build.src` and `build.classes` and will be replaced by their respective values during runtime. I've also added values for gradle and maven defaults. 

Should we also add this to the documentation?