### PR TITLE
Preserve package directories and nested classes in pattern compile

### DIFF
--- a/mubench.pipeline/tasks/implementations/compile_misuse.py
+++ b/mubench.pipeline/tasks/implementations/compile_misuse.py
@@ -40,7 +40,7 @@ class CompileMisuseTask:
 
             if pattern_compile.needs_compile():
                 logger.info("Compiling patterns...")
-                CompileMisuseTask._compile_patterns(misuse.pattern_path,
+                CompileMisuseTask._compile_patterns(pattern_compile.pattern_sources_path,
                                                     pattern_compile.pattern_classes_path,
                                                     version_compile.get_full_classpath())
             else:

--- a/mubench.pipeline/tasks/implementations/compile_misuse.py
+++ b/mubench.pipeline/tasks/implementations/compile_misuse.py
@@ -54,8 +54,11 @@ class CompileMisuseTask:
     @staticmethod
     def _compile_patterns(source: str, destination: str, classpath: str):
         makedirs(destination, exist_ok=True)
-        Shell.exec('javac $(find {} -name "*.java") -d "{}" -cp "{}"'.format(source, destination, classpath),
-                   logger=logging.getLogger("task.compile_patterns.compile"))
+        for root, dirs, files in walk(source):
+            for java_file in [f for f in files if f.endswith(".java")]:
+                destination = dirname(join(destination, java_file))
+                Shell.exec('javac "{}" -d "{}" -cp "{}"'.format(join(root, java_file), destination, classpath),
+                           logger=logging.getLogger("task.compile_patterns.compile"))
 
     @staticmethod
     def _copy_misuse_sources(sources_path, misuse, destination):

--- a/mubench.pipeline/tests/tasks/implementations/test_compile_misuse.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_compile_misuse.py
@@ -61,7 +61,8 @@ class TestCompilePatterns:
 
         uut.run(self.misuse, self.compile)
 
-        self.compile_mock.assert_called_once_with(self.misuse.pattern_path, self.misuse_compile.pattern_classes_path,
+        self.compile_mock.assert_called_once_with(self.misuse_compile.pattern_sources_path,
+                                                  self.misuse_compile.pattern_classes_path,
                                                   self.compile.get_full_classpath())
 
     def test_skips_compile_if_not_needed(self):
@@ -79,7 +80,8 @@ class TestCompilePatterns:
 
         uut.run(self.misuse, self.compile)
 
-        self.compile_mock.assert_called_once_with(self.misuse.pattern_path, self.misuse_compile.pattern_classes_path,
+        self.compile_mock.assert_called_once_with(self.misuse_compile.pattern_sources_path,
+                                                  self.misuse_compile.pattern_classes_path,
                                                   self.compile.get_full_classpath())
 
     def test_copies_misuse_sources(self):


### PR DESCRIPTION
Fix #223 Pattern compile ignores package directories and nested classes.

- We now use the copied patterns for compiles (data sub-directories are only used for the initial source copy).
- We now walk over the source files in python and make a separate `javac` call for each file. This way we give `javac` the correct subdirectory destination, keeping the package directory structure for pattern classes.