### PR TITLE
Force compile after force checkout

### DIFF
--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import calendar
 import logging.handlers
 import sys
 from datetime import datetime
@@ -40,7 +40,8 @@ class Benchmark:
 
 
 config = config_util.get_config(sys.argv)
-
+now = datetime.utcnow()
+config.run_timestamp = calendar.timegm(now.timetuple())
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)

--- a/mubench.pipeline/data/misuse.py
+++ b/mubench.pipeline/data/misuse.py
@@ -130,7 +130,7 @@ class Misuse:
         return get_snippets(source_base_path, self.location.file, self.location.method)
 
     def get_misuse_compile(self, base_path: str) -> MisuseCompile:
-        return MisuseCompile(join(base_path, self.project_id, self.misuse_id), self.patterns)
+        return MisuseCompile(join(base_path, self.project_id, "misuses", self.misuse_id), self.patterns)
 
     def __str__(self):
         return "misuse '{}'".format(self.id)

--- a/mubench.pipeline/data/misuse_compile.py
+++ b/mubench.pipeline/data/misuse_compile.py
@@ -1,8 +1,10 @@
-from os.path import join, isdir
+from os.path import join, isdir, exists
 from typing import Set
 
+from os import remove
+
 from data.pattern import Pattern
-from utils.io import remove_tree
+from utils.io import remove_tree, write_yaml, read_yaml
 
 
 class MisuseCompile:
@@ -10,6 +12,9 @@ class MisuseCompile:
     PATTERN_CLASSES_DIR = "patterns-classes"
     MISUSE_SOURCE_DIR = "misuse-src"
     MISUSE_CLASSES_DIR = "misuse-classes"
+    __MISUSE_COMPILE_FILE = "misuse_compile.yml"
+    __TIMESTAMP_KEY = "timestamp"
+    __DEFAULT_TIMESTAMP = 0
 
     def __init__(self, base_path: str, patterns: Set[Pattern]):
         self.base_path = base_path
@@ -20,14 +25,31 @@ class MisuseCompile:
         self.misuse_source_path = join(self.base_path, MisuseCompile.MISUSE_SOURCE_DIR)
         self.misuse_classes_path = join(self.base_path, MisuseCompile.MISUSE_CLASSES_DIR)
 
+        self._misuse_compile_file = join(self.base_path, MisuseCompile.__MISUSE_COMPILE_FILE)
+
     def needs_copy_sources(self):
         return self.patterns and not isdir(self.pattern_sources_path)
 
     def needs_compile(self):
         return self.patterns and not isdir(self.pattern_classes_path)
 
+    @property
+    def timestamp(self):
+        timestamp = self.__DEFAULT_TIMESTAMP
+
+        if exists(self._misuse_compile_file):
+            compile_info = read_yaml(self._misuse_compile_file)
+            timestamp = compile_info.get(self.__TIMESTAMP_KEY, self.__DEFAULT_TIMESTAMP)
+
+        return timestamp
+
+    def save(self, timestamp: int):
+        misuse_compile_info = {self.__TIMESTAMP_KEY: timestamp}
+        write_yaml(misuse_compile_info, self._misuse_compile_file)
+
     def delete(self):
         remove_tree(self.pattern_sources_path)
         remove_tree(self.pattern_classes_path)
         remove_tree(self.misuse_source_path)
         remove_tree(self.misuse_classes_path)
+        remove_tree(self._misuse_compile_file)

--- a/mubench.pipeline/data/project_checkout.py
+++ b/mubench.pipeline/data/project_checkout.py
@@ -3,23 +3,43 @@ from os import listdir, makedirs
 from os.path import join, exists
 from zipfile import ZipFile
 
-from utils.io import copy_tree, remove_tree
+from utils.io import copy_tree, remove_tree, write_yaml, read_yaml
 from utils.shell import Shell
 from utils.web_util import download_file
 
 
 class ProjectCheckout:
+    __CHECKOUT_INFO_FILE = "checkout.yml"
+    __KEY_TIMESTAMP = "timestamp"
+    __DEFAULT_TIMESTAMP = 0
+
     def __init__(self, url: str, base_path: str, name: str):
         self._logger = logging.getLogger("checkout.project")
         self.url = url
         self.base_path = base_path
         self.name = name
         self.checkout_dir = join(self.base_path, name, "checkout")
+        self._checkout_info_file = join(self.checkout_dir, ProjectCheckout.__CHECKOUT_INFO_FILE)
+
+    @property
+    def timestamp(self) -> int:
+        timestamp = self.__DEFAULT_TIMESTAMP
+
+        if exists(self._checkout_info_file):
+            checkout_info = read_yaml(self._checkout_info_file)
+            timestamp = checkout_info.get(ProjectCheckout.__KEY_TIMESTAMP, self.__DEFAULT_TIMESTAMP)
+
+        return timestamp
 
     def exists(self) -> bool:
         raise NotImplementedError
 
-    def create(self) -> None:
+    def create(self, current_timestamp: int) -> None:
+        self._create()
+        checkout_info = {ProjectCheckout.__KEY_TIMESTAMP: current_timestamp}
+        write_yaml(checkout_info, self._checkout_info_file)
+
+    def _create(self):
         raise NotImplementedError
 
     def delete(self) -> None:
@@ -30,7 +50,7 @@ class LocalProjectCheckout(ProjectCheckout):
     def exists(self):
         return exists(self.checkout_dir) and listdir(self.checkout_dir)
 
-    def create(self):
+    def _create(self):
         if not exists(self.checkout_dir):
             self._logger.debug("Create checkout directory %s", self.checkout_dir)
             makedirs(self.checkout_dir)
@@ -59,7 +79,7 @@ class SyntheticProjectCheckout(ProjectCheckout):
         self._logger.debug("Delete %s", self.checkout_dir)
         remove_tree(self.checkout_dir)
 
-    def create(self) -> None:
+    def _create(self) -> None:
         if not exists(self.checkout_dir):
             self._logger.debug("Create checkout directory %s", self.checkout_dir)
             makedirs(self.checkout_dir)
@@ -80,7 +100,7 @@ class ZipProjectCheckout(ProjectCheckout):
     def delete(self) -> None:
         remove_tree(self.checkout_dir)
 
-    def create(self) -> None:
+    def _create(self) -> None:
         makedirs(self.checkout_dir, exist_ok=True)
         bundle_file = join(self.checkout_dir, "bundle.zip")
         download_file(self.url, bundle_file, self.md5_checksum)
@@ -106,7 +126,7 @@ class RepoProjectCheckout(ProjectCheckout):
     def exists(self):
         return self.__child.exists() and self._is_repo(self.checkout_dir)
 
-    def create(self):
+    def _create(self):
         if not self._is_repo(self.__base_checkout_dir):
             self._logger.debug("Create base checkout directory %s", self.__base_checkout_dir)
             makedirs(self.__base_checkout_dir, exist_ok=True)
@@ -114,7 +134,7 @@ class RepoProjectCheckout(ProjectCheckout):
             self._clone(self.url, self.revision, self.__base_checkout_dir)
 
         if not self._is_repo(self.__child.checkout_dir):
-            self.__child.create()
+            self.__child._create()
             self._logger.debug("Update to revision %s", self.revision)
             self._update(self.url, self.revision, self.__child.checkout_dir)
 
@@ -158,7 +178,7 @@ class SVNProjectCheckout(ProjectCheckout):
         self.__base_checkout_dir = self.checkout_dir
         self.checkout_dir = join(self.base_path, name, version, "checkout")
 
-    def create(self) -> None:
+    def _create(self) -> None:
         self._logger.debug("Create checkout directory %s", self.checkout_dir)
         makedirs(self.checkout_dir, exist_ok=True)
         self._logger.debug("Checkout from %s", self.url)

--- a/mubench.pipeline/data/version_compile.py
+++ b/mubench.pipeline/data/version_compile.py
@@ -1,9 +1,9 @@
 import os
-from os.path import join, isdir
+from os.path import join, isdir, exists
 from typing import List
 
 from data.misuse import Misuse
-from utils.io import remove_tree
+from utils.io import remove_tree, write_yaml, read_yaml
 
 
 class VersionCompile:
@@ -13,6 +13,9 @@ class VersionCompile:
     MISUSE_CLASSES_DIR = "misuse-classes"
     DEPENDENCY_DIR = "dependencies"
     __BUILD_DIR = "build"
+    __COMPILE_INFO_FILE = "compile.yml"
+    __KEY_TIMESTAMP = "timestamp"
+    __DEFAULT_TIMESTAMP = 0
 
     def __init__(self, base_path: str, misuses: List[Misuse]):
         self.base_path = base_path
@@ -23,6 +26,7 @@ class VersionCompile:
         self.original_classpath = self.original_classes_path + ".jar"
         self.dependencies_path = join(self.base_path, VersionCompile.DEPENDENCY_DIR)
         self.build_dir = join(self.base_path, VersionCompile.__BUILD_DIR)
+        self._compile_info_file = join(self.build_dir, self.__COMPILE_INFO_FILE)
 
     def needs_copy_sources(self):
         return not isdir(self.original_classes_path)
@@ -42,6 +46,20 @@ class VersionCompile:
             return "{}:{}".format(dependency_classpath, self.original_classpath)
         else:
             return self.original_classpath
+
+    @property
+    def timestamp(self) -> int:
+        timestamp = VersionCompile.__DEFAULT_TIMESTAMP
+
+        if exists(self._compile_info_file):
+            checkout_info = read_yaml(self._compile_info_file)
+            timestamp = checkout_info.get(VersionCompile.__KEY_TIMESTAMP, VersionCompile.__DEFAULT_TIMESTAMP)
+
+        return timestamp
+
+    def save(self, current_timestamp: int):
+        compile_info = {VersionCompile.__KEY_TIMESTAMP: current_timestamp}
+        write_yaml(compile_info, self._compile_info_file)
 
     def delete(self):
         remove_tree(self.original_sources_path)

--- a/mubench.pipeline/tasks/configurations/configurations.py
+++ b/mubench.pipeline/tasks/configurations/configurations.py
@@ -65,10 +65,10 @@ class CheckoutTaskConfiguration(TaskConfiguration):
     def mode() -> str:
         return "checkout"
 
-    def tasks(self, config):
+    def tasks(self, config) -> List:
         collect_projects = CollectProjectsTask(config.data_path)
         collect_versions = CollectVersionsTask()
-        checkout = CheckoutTask(config.checkouts_path, config.force_checkout, config.use_tmp_wrkdir)
+        checkout = CheckoutTask(config.checkouts_path, config.run_timestamp, config.force_checkout, config.use_tmp_wrkdir)
         return [collect_projects, collect_versions, checkout]
 
 
@@ -78,9 +78,10 @@ class CompileTaskConfiguration(TaskConfiguration):
         return "compile"
 
     def tasks(self, config) -> List:
-        compile_version = CompileVersionTask(config.compiles_path, config.force_compile, config.use_tmp_wrkdir)
+        compile_version = CompileVersionTask(config.compiles_path, config.run_timestamp, config.force_compile,
+                                             config.use_tmp_wrkdir)
         collect_misuses = CollectMisusesTask()
-        compile_misuse = CompileMisuseTask(config.compiles_path, config.force_compile)
+        compile_misuse = CompileMisuseTask(config.compiles_path, config.run_timestamp, config.force_compile)
         return CheckoutTaskConfiguration().tasks(config) + [compile_version, collect_misuses, compile_misuse]
 
 
@@ -92,9 +93,10 @@ class RunProvidedPatternsExperiment(TaskConfiguration):
         return "run {}".format(RunProvidedPatternsExperiment.ID)
 
     def tasks(self, config) -> List:
-        compile_version = CompileVersionTask(config.compiles_path, config.force_compile, config.use_tmp_wrkdir)
+        compile_version = CompileVersionTask(config.compiles_path, config.run_timestamp, config.force_compile,
+                                             config.use_tmp_wrkdir)
         collect_misuses = CollectMisusesTask()
-        compile_misuse = CompileMisuseTask(config.compiles_path, config.force_compile)
+        compile_misuse = CompileMisuseTask(config.compiles_path, config.run_timestamp, config.force_compile)
         load_detector = LoadDetectorTask(config.detectors_path, config.detector, config.requested_release,
                                          config.java_options)
         detect = DetectProvidedPatternsTask(config.findings_path, config.force_detect, config.timeout)

--- a/mubench.pipeline/tasks/implementations/checkout.py
+++ b/mubench.pipeline/tasks/implementations/checkout.py
@@ -8,13 +8,14 @@ from utils.io import copy_tree, remove_tree
 
 
 class CheckoutTask:
-    def __init__(self, checkouts_path: str, force_checkout: bool, use_temp_dir: bool):
+    def __init__(self, checkouts_path: str, run_timestamp: int, force_checkout: bool, use_temp_dir: bool):
         super().__init__()
         self.checkouts_path = checkouts_path
         self.force_checkout = force_checkout
         self.use_temp_dir = use_temp_dir
+        self.run_timestamp = run_timestamp
 
-    def run(self, version: ProjectVersion) -> ProjectCheckout:
+    def run(self, version: ProjectVersion):
         logger = logging.getLogger("tasks.checkout")
 
         try:
@@ -33,11 +34,11 @@ class CheckoutTask:
             if self.use_temp_dir:
                 temp_dir = mkdtemp(prefix="mubench-checkout_")
                 temp_checkout = version.get_checkout(temp_dir)
-                temp_checkout.create()
+                temp_checkout.create(self.run_timestamp)
                 logger.debug("Copying checkout to persistent directory...")
                 copy_tree(temp_dir, self.checkouts_path)
                 remove_tree(temp_dir)
             else:
-                checkout.create()
+                checkout.create(self.run_timestamp)
 
         return checkout

--- a/mubench.pipeline/tasks/implementations/compile_misuse.py
+++ b/mubench.pipeline/tasks/implementations/compile_misuse.py
@@ -20,41 +20,41 @@ class CompileMisuseTask:
     def run(self, misuse: Misuse, version_compile: VersionCompile):
         logger = logging.getLogger("task.compile_patterns")
 
-        pattern_compile = misuse.get_misuse_compile(self.compile_base_path)
+        misuse_compile = misuse.get_misuse_compile(self.compile_base_path)
 
-        if self.force_compile or version_compile.timestamp > pattern_compile.timestamp:
-            pattern_compile.delete()
+        if self.force_compile or version_compile.timestamp > misuse_compile.timestamp:
+            misuse_compile.delete()
 
         logger.info("Compiling %s...", misuse)
 
         logger.debug("Copying misuse sources...")
         CompileMisuseTask._copy_misuse_sources(version_compile.original_sources_path,
                                                misuse,
-                                               pattern_compile.misuse_source_path)
+                                               misuse_compile.misuse_source_path)
         logger.debug("Copying misuse classes...")
         CompileMisuseTask._copy_misuse_classes(version_compile.original_classes_path,
                                                misuse,
-                                               pattern_compile.misuse_classes_path)
+                                               misuse_compile.misuse_classes_path)
 
         try:
             logger.info("Compiling correct usage for %s...", misuse)
-            if pattern_compile.needs_copy_sources():
+            if misuse_compile.needs_copy_sources():
                 logger.debug("Copying correct-usage sources...")
-                copy_tree(misuse.pattern_path, pattern_compile.pattern_sources_path)
+                copy_tree(misuse.pattern_path, misuse_compile.pattern_sources_path)
 
-            if pattern_compile.needs_compile():
+            if misuse_compile.needs_compile():
                 logger.debug("Compiling correct usages...")
-                CompileMisuseTask._compile_patterns(pattern_compile.pattern_sources_path,
-                                                    pattern_compile.pattern_classes_path,
+                CompileMisuseTask._compile_patterns(misuse_compile.pattern_sources_path,
+                                                    misuse_compile.pattern_classes_path,
                                                     version_compile.get_full_classpath())
-                pattern_compile.save(self.run_timestamp)
+                misuse_compile.save(self.run_timestamp)
             else:
                 logger.info("Correct usage already compiled.")
         except Exception:
-            pattern_compile.delete()
+            misuse_compile.delete()
             raise
 
-        return pattern_compile
+        return misuse_compile
 
     @staticmethod
     def _compile_patterns(source: str, destination: str, classpath: str):

--- a/mubench.pipeline/tasks/implementations/compile_misuse.py
+++ b/mubench.pipeline/tasks/implementations/compile_misuse.py
@@ -12,8 +12,9 @@ from utils.shell import Shell
 
 
 class CompileMisuseTask:
-    def __init__(self, compile_base_path: str, force_compile: bool):
+    def __init__(self, compile_base_path: str, run_timestamp: int, force_compile: bool):
         self.compile_base_path = compile_base_path
+        self.run_timestamp = run_timestamp
         self.force_compile = force_compile
 
     def run(self, misuse: Misuse, version_compile: VersionCompile):
@@ -21,7 +22,7 @@ class CompileMisuseTask:
 
         pattern_compile = misuse.get_misuse_compile(self.compile_base_path)
 
-        if self.force_compile:
+        if self.force_compile or version_compile.timestamp > pattern_compile.timestamp:
             pattern_compile.delete()
 
         logger.info("Compiling %s...", misuse)
@@ -46,6 +47,7 @@ class CompileMisuseTask:
                 CompileMisuseTask._compile_patterns(pattern_compile.pattern_sources_path,
                                                     pattern_compile.pattern_classes_path,
                                                     version_compile.get_full_classpath())
+                pattern_compile.save(self.run_timestamp)
             else:
                 logger.info("Correct usage already compiled.")
         except Exception:

--- a/mubench.pipeline/tasks/implementations/compile_version.py
+++ b/mubench.pipeline/tasks/implementations/compile_version.py
@@ -14,9 +14,10 @@ from utils.io import remove_tree, copy_tree
 
 
 class CompileVersionTask:
-    def __init__(self, compiles_base_path: str, force_compile: bool, use_temp_dir: bool):
+    def __init__(self, compiles_base_path: str, run_timestamp: int, force_compile: bool, use_temp_dir: bool):
         super().__init__()
         self.compiles_base_path = compiles_base_path
+        self.run_timestamp = run_timestamp
         self.force_compile = force_compile
         self.use_temp_dir = use_temp_dir
 
@@ -31,7 +32,7 @@ class CompileVersionTask:
         sources_path = join(build_path, version.source_dir)
         classes_path = join(build_path, version.classes_dir)
 
-        if self.force_compile:
+        if self.force_compile or checkout.timestamp > version_compile.timestamp:
             logger.debug("Force compile - removing previous compiles...")
             version_compile.delete()
 
@@ -68,6 +69,8 @@ class CompileVersionTask:
                 copy_tree(classes_path, version_compile.original_classes_path)
                 logger.debug("Create project jar...")
                 self.__create_jar(version_compile.original_classes_path, version_compile.original_classpath)
+
+                version_compile.save(self.run_timestamp)
 
             if self.use_temp_dir:
                 logger.debug("Moving complete build to persistent directory...")

--- a/mubench.pipeline/tests/data/test_misuse_compile.py
+++ b/mubench.pipeline/tests/data/test_misuse_compile.py
@@ -1,0 +1,22 @@
+from tempfile import mkdtemp
+
+from nose.tools import assert_equals
+
+from data.misuse_compile import MisuseCompile
+from utils.io import remove_tree
+
+
+class TestMisuseCompile:
+    def setup(self):
+        self.temp_dir = mkdtemp(prefix="mubench_misuse_compile-")
+
+    def teardown(self):
+        remove_tree(self.temp_dir)
+
+    def test_saves_timestamp(self):
+        test_timestamp = 1516359089
+        uut = MisuseCompile(self.temp_dir, [])
+
+        uut.save(test_timestamp)
+
+        assert_equals(test_timestamp, uut.timestamp)

--- a/mubench.pipeline/tests/data/test_version_compile.py
+++ b/mubench.pipeline/tests/data/test_version_compile.py
@@ -1,4 +1,7 @@
+from tempfile import mkdtemp
 from unittest.mock import patch
+
+from shutil import rmtree
 
 from data.version_compile import VersionCompile
 from nose.tools import assert_equals
@@ -6,6 +9,12 @@ from nose.tools import assert_equals
 
 @patch("data.version_compile.isdir")
 class TestDependencyClasspath:
+    def setup(self):
+        self.temp_dir = mkdtemp(prefix="mubench-version-compile_")
+
+    def teardown(self):
+        rmtree(self.temp_dir)
+
     def test_no_dependencies(self, isdir_mock):
         isdir_mock.return_value = False
         pc = VersionCompile("/base/", [])
@@ -23,3 +32,13 @@ class TestDependencyClasspath:
         cp = pc.get_dependency_classpath()
 
         assert_equals(cp, "/base/dependencies/foo.jar:/base/dependencies/bar.jar")
+
+    def test_uses_zero_time_if_never_saved(self, _):
+        uut = VersionCompile(self.temp_dir, [])
+        assert_equals(0, uut.timestamp)
+
+    def test_saves_timestamp(self, _):
+        test_timestamp = 1516183458
+        uut = VersionCompile(self.temp_dir, [])
+        uut.save(test_timestamp)
+        assert_equals(test_timestamp, uut.timestamp)

--- a/mubench.pipeline/tests/tasks/implementations/test_checkout.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_checkout.py
@@ -20,7 +20,9 @@ class TestCheckout(unittest.TestCase):
         self.version = create_version("-version-", project=self.project)
         self.version.get_checkout = MagicMock(return_value=self.checkout)
 
-        self.uut = CheckoutTask("-checkouts-", force_checkout=False, use_temp_dir=False)
+        self.run_timestamp = 1516186439
+
+        self.uut = CheckoutTask("-checkouts-", self.run_timestamp, force_checkout=False, use_temp_dir=False)
 
     def test_initial_checkout(self):
         self.checkout.exists = MagicMock(return_value=False)
@@ -28,7 +30,7 @@ class TestCheckout(unittest.TestCase):
         response = self.uut.run(self.version)
 
         self.checkout.delete.assert_not_called()
-        self.checkout.create.assert_called_with()
+        self.checkout.create.assert_called_with(self.run_timestamp)
         assert_equals(self.checkout, response)
 
     def test_exists(self):
@@ -58,4 +60,4 @@ class TestCheckout(unittest.TestCase):
         self.uut.run(self.version)
 
         self.checkout.delete.assert_called_with()
-        self.checkout.create.assert_called_with()
+        self.checkout.create.assert_called_with(self.run_timestamp)


### PR DESCRIPTION
Implements Force checkout implies force compile #195

We now generate a timestamp at the beginning of each MuBench run. This is used as a run id and saved by checkout and compile. If the checkout time is more recent than the compile time, we're recompiling.