### PR TITLE
Implement #232: Exclude non compilable versions per default

### DIFF
--- a/mubench.pipeline/crossproject_create_index.py
+++ b/mubench.pipeline/crossproject_create_index.py
@@ -20,5 +20,5 @@ class Task:
 
 white_list = get_white_list("../data/datasets.yml", "icse16ex1")
 initial_parameters = [DataEntityLists(white_list, [])]
-runner = TaskRunner([CollectProjectsTask("../data/"), CollectVersionsTask(), CollectMisusesTask(), Task()])
+runner = TaskRunner([CollectProjectsTask("../data/"), CollectVersionsTask(False), CollectMisusesTask(), Task()])
 runner.run(*initial_parameters)

--- a/mubench.pipeline/data/project_version.py
+++ b/mubench.pipeline/data/project_version.py
@@ -120,6 +120,10 @@ class ProjectVersion:
     def additional_compile_sources(self) -> str:
         return join(self.path, 'compile')
 
+    @property
+    def is_compilable(self) -> bool:
+        return self.source_dirs and self.compile_commands and self.classes_dirs
+
     def __str__(self):
         return "project '{}' version {}".format(self.project_id, self.version_id)
 

--- a/mubench.pipeline/tasks/configurations/configurations.py
+++ b/mubench.pipeline/tasks/configurations/configurations.py
@@ -52,7 +52,7 @@ class InfoTaskConfiguration(TaskConfiguration):
 
     def tasks(self, config) -> List:
         collect_projects = CollectProjectsTask(config.data_path)
-        collect_versions = CollectVersionsTask()
+        collect_versions = CollectVersionsTask(config.development_mode)
         collect_misuses = CollectMisusesTask()
         project_info = ProjectInfoTask(config.checkouts_path, config.compiles_path)
         version_info = VersionInfoTask(config.checkouts_path, config.compiles_path)
@@ -67,7 +67,7 @@ class CheckoutTaskConfiguration(TaskConfiguration):
 
     def tasks(self, config) -> List:
         collect_projects = CollectProjectsTask(config.data_path)
-        collect_versions = CollectVersionsTask()
+        collect_versions = CollectVersionsTask(config.development_mode)
         checkout = CheckoutTask(config.checkouts_path, config.run_timestamp, config.force_checkout, config.use_tmp_wrkdir)
         return [collect_projects, collect_versions, checkout]
 
@@ -192,7 +192,7 @@ class StatsTaskConfiguration(TaskConfiguration):
 
     def tasks(self, config) -> List:
         collect_projects = CollectProjectsTask(config.data_path)
-        collect_versions = CollectVersionsTask()
+        collect_versions = CollectVersionsTask(config.development_mode)
         collect_misuses = CollectMisusesTask()
         calculator = stats.get_calculator(config.script)
         return [collect_projects, collect_versions, collect_misuses, calculator]
@@ -214,7 +214,7 @@ class DatasetCheckTaskConfiguration(TaskConfiguration):
 
     def tasks(self, config) -> List:
         collect_projects = CollectProjectsTask(config.data_path)
-        collect_versions = CollectVersionsTask()
+        collect_versions = CollectVersionsTask(config.development_mode)
         collect_misuses = CollectMisusesTask()
         project_check = ProjectCheckTask()
         version_check = VersionCheckTask()

--- a/mubench.pipeline/tasks/implementations/collect_versions.py
+++ b/mubench.pipeline/tasks/implementations/collect_versions.py
@@ -1,17 +1,27 @@
 from data.project import Project
+from data.project_version import ProjectVersion
 from utils.data_entity_lists import DataEntityLists
 
 
 class CollectVersionsTask:
+    def __init__(self, development_mode: bool):
+        self._filter_non_compilable_versions = not development_mode
+
     def run(self, project: Project, data_entity_lists: DataEntityLists):
         return [version for version in project.versions
-                if not self.__is_filtered(project.id, version.id, data_entity_lists)]
+                if not self.__is_filtered(project.id, version, data_entity_lists, self._filter_non_compilable_versions)]
 
     @staticmethod
-    def __is_filtered(project_id: str, version_id: str, data_entity_lists: DataEntityLists) -> bool:
+    def __is_filtered(project_id: str, version: ProjectVersion, data_entity_lists: DataEntityLists,
+                      filter_non_compilable_versions: bool) -> bool:
+        if filter_non_compilable_versions:
+            return not version.is_compilable
+
+        version_id = version.id
         white_list = data_entity_lists.get_version_white_list(project_id)
         black_list = data_entity_lists.black_list
 
         is_whitelisted = not white_list or version_id in white_list
         is_blacklisted = version_id in black_list
+
         return is_blacklisted or not is_whitelisted

--- a/mubench.pipeline/tasks/implementations/collect_versions.py
+++ b/mubench.pipeline/tasks/implementations/collect_versions.py
@@ -9,19 +9,15 @@ class CollectVersionsTask:
 
     def run(self, project: Project, data_entity_lists: DataEntityLists):
         return [version for version in project.versions
-                if not self.__is_filtered(project.id, version, data_entity_lists, self._filter_non_compilable_versions)]
+                if not self.__is_filtered(project.id, version, data_entity_lists)]
 
-    @staticmethod
-    def __is_filtered(project_id: str, version: ProjectVersion, data_entity_lists: DataEntityLists,
-                      filter_non_compilable_versions: bool) -> bool:
-        if filter_non_compilable_versions:
-            return not version.is_compilable
-
+    def __is_filtered(self, project_id: str, version: ProjectVersion, data_entity_lists: DataEntityLists) -> bool:
         version_id = version.id
         white_list = data_entity_lists.get_version_white_list(project_id)
         black_list = data_entity_lists.black_list
 
         is_whitelisted = not white_list or version_id in white_list
         is_blacklisted = version_id in black_list
+        is_not_compilable = self._filter_non_compilable_versions and not version.is_compilable
 
-        return is_blacklisted or not is_whitelisted
+        return is_not_compilable or is_blacklisted or not is_whitelisted

--- a/mubench.pipeline/tests/data/test_project_version.py
+++ b/mubench.pipeline/tests/data/test_project_version.py
@@ -98,6 +98,16 @@ class TestProjectVersion:
 
         assert_equals(join("/base/path/", self.project_id, self.version_id, "build"), version_compile.build_dir)
 
+    def test_is_not_compilable(self):
+        self.uut._YAML = {"build": {}}
+        assert not self.uut.is_compilable
+
+    def test_is_compilable(self):
+        self.uut._YAML = {"build": {"src": "src/java/",
+                                    "commands": ["mvn compile"],
+                                    "classes": "/target/classes/"}}
+        assert self.uut.is_compilable
+
 
 class TestProjectCheckout:
     def test_synthetic_project(self):

--- a/mubench.pipeline/tests/tasks/implementations/test_collect_versions.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_collect_versions.py
@@ -7,54 +7,59 @@ from tests.test_utils.data_util import create_project, create_version
 from utils.data_entity_lists import DataEntityLists
 
 
+@patch("data.project_version.ProjectVersion.is_compilable", new_callable=PropertyMock)
 class TestCollectVersions:
-    def test_finds_all_versions(self):
+    def test_finds_all_versions(self, version_is_compilable_mock):
         project = create_project("-project-")
         v1 = create_version("-v1-", project=project)
         v2 = create_version("-v2-", project=project)
-        uut = CollectVersionsTask(True)
+        version_is_compilable_mock.return_value = True
+        uut = CollectVersionsTask(False)
 
         actual = uut.run(project, DataEntityLists([], []))
 
         assert_equals([v1, v2], actual)
 
-    def test_whitelisted_project(self):
+    def test_whitelisted_project(self, version_is_compilable_mock):
         project = create_project("-project-")
         version = create_version("-id-", project=project)
-        uut = CollectVersionsTask(True)
+        version_is_compilable_mock.return_value = True
+        uut = CollectVersionsTask(False)
 
         actual = uut.run(project, DataEntityLists(["-project-"], []))
 
         assert_equals([version], actual)
 
-    def test_whitelisted_version(self):
+    def test_whitelisted_version(self, version_is_compilable_mock):
         project = create_project("-project-")
         version = create_version("-id-", project=project)
-        uut = CollectVersionsTask(True)
+        version_is_compilable_mock.return_value = True
+        uut = CollectVersionsTask(False)
 
         actual = uut.run(project, DataEntityLists(["-project-.-id-"], []))
 
         assert_equals([version], actual)
 
-    def test_filters_if_not_whitelisted(self):
+    def test_filters_if_not_whitelisted(self, version_is_compilable_mock):
         project = create_project("-project-")
         create_version("-id-", project=project)
-        uut = CollectVersionsTask(True)
+        version_is_compilable_mock.return_value = True
+        uut = CollectVersionsTask(False)
 
         actual = uut.run(project, DataEntityLists(["-project-.-other-id-"], []))
 
         assert_equals([], actual)
 
-    def test_filters_blacklisted(self):
+    def test_filters_blacklisted(self, version_is_compilable_mock):
         project = create_project("-project-")
         create_version("-id-", project=project)
-        uut = CollectVersionsTask(True)
+        version_is_compilable_mock.return_value = True
+        uut = CollectVersionsTask(False)
 
         actual = uut.run(project, DataEntityLists([], ["-project-.-id-"]))
 
         assert_equals([], actual)
 
-    @patch("data.project_version.ProjectVersion.is_compilable", new_callable=PropertyMock)
     def test_filters_not_compilable(self, version_is_compilable_mock):
         project = create_project("-project-")
         create_version("-id-", project=project)

--- a/mubench.pipeline/tests/tasks/implementations/test_collect_versions.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_collect_versions.py
@@ -12,7 +12,7 @@ class TestCollectVersions:
         project = create_project("-project-")
         v1 = create_version("-v1-", project=project)
         v2 = create_version("-v2-", project=project)
-        uut = CollectVersionsTask(False)
+        uut = CollectVersionsTask(True)
 
         actual = uut.run(project, DataEntityLists([], []))
 
@@ -21,7 +21,7 @@ class TestCollectVersions:
     def test_whitelisted_project(self):
         project = create_project("-project-")
         version = create_version("-id-", project=project)
-        uut = CollectVersionsTask(False)
+        uut = CollectVersionsTask(True)
 
         actual = uut.run(project, DataEntityLists(["-project-"], []))
 
@@ -30,7 +30,7 @@ class TestCollectVersions:
     def test_whitelisted_version(self):
         project = create_project("-project-")
         version = create_version("-id-", project=project)
-        uut = CollectVersionsTask(False)
+        uut = CollectVersionsTask(True)
 
         actual = uut.run(project, DataEntityLists(["-project-.-id-"], []))
 
@@ -39,7 +39,7 @@ class TestCollectVersions:
     def test_filters_if_not_whitelisted(self):
         project = create_project("-project-")
         create_version("-id-", project=project)
-        uut = CollectVersionsTask(False)
+        uut = CollectVersionsTask(True)
 
         actual = uut.run(project, DataEntityLists(["-project-.-other-id-"], []))
 
@@ -48,7 +48,7 @@ class TestCollectVersions:
     def test_filters_blacklisted(self):
         project = create_project("-project-")
         create_version("-id-", project=project)
-        uut = CollectVersionsTask(False)
+        uut = CollectVersionsTask(True)
 
         actual = uut.run(project, DataEntityLists([], ["-project-.-id-"]))
 
@@ -59,7 +59,7 @@ class TestCollectVersions:
         project = create_project("-project-")
         create_version("-id-", project=project)
         version_is_compilable_mock.return_value = False
-        uut = CollectVersionsTask(True)
+        uut = CollectVersionsTask(False)
 
         actual = uut.run(project, DataEntityLists([], []))
 

--- a/mubench.pipeline/utils/config_util.py
+++ b/mubench.pipeline/utils/config_util.py
@@ -66,6 +66,8 @@ def _get_command_line_parser(available_detectors: List[str], available_scripts: 
              "Run `./mubench <task> -h` for details.",
         dest='task')
 
+    subparsers.required = True
+
     parser.add_argument('--use-tmp-wrkdir', dest='use_tmp_wrkdir', default=__get_default('use-tmp-wrkdir', False),
                         help=argparse.SUPPRESS, action='store_true')
     parser.add_argument('--data-path', dest='data_path', default=__get_default('data-path', __DATA_PATH),
@@ -80,6 +82,8 @@ def _get_command_line_parser(available_detectors: List[str], available_scripts: 
                         default=__get_default('datasets-file-path', __DATASETS_FILE_PATH), help=argparse.SUPPRESS)
     parser.add_argument('--detectors-path', dest='detectors_path',
                         default=__get_default('detectors-path', __DETECTORS_PATH), help=argparse.SUPPRESS)
+    parser.add_argument('--development-mode', dest='development_mode', default=__get_default('development-mode', False),
+                        help=argparse.SUPPRESS, action='store_true')
 
     __add_check_subprocess(available_datasets, subparsers)
     __add_info_subprocess(available_datasets, subparsers)


### PR DESCRIPTION
Use `--development-mode` (abbreviations are enabled, so `-dev` works as well) to disable this feature.