### PR TITLE
Implement  #239: Provide Classpaths as Objects

### DIFF
--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
@@ -1,7 +1,7 @@
 package de.tu_darmstadt.stg.mubench.cli;
 
 public class ClassPath {
-    private String path;
+    private final String path;
 
     public ClassPath(String path) {
         this.path = path;
@@ -19,15 +19,27 @@ public class ClassPath {
         return path;
     }
 
-    public void append(ClassPath other){
-        if (other.getClasspath() != null && !other.getClasspath().isEmpty()) {
-            this.path += ":" + other.getClasspath();
+    public ClassPath join(ClassPath other){
+        if (other.getClasspath() == null || other.getClasspath().isEmpty()) {
+            return new ClassPath(path);
         }
+
+        if (path == null || path.isEmpty()) {
+            return new ClassPath(other.getClasspath());
+        }
+
+        return new ClassPath(path + ":" + other.getClasspath());
     }
 
-    public void append(String entry) {
-        if (entry != null && !entry.isEmpty()) {
-            this.path += ":" + entry;
+    public ClassPath join(String entry) {
+        if (entry == null || entry.isEmpty()) {
+            return new ClassPath(path);
         }
+
+        if (path == null || path.isEmpty()) {
+            return new ClassPath(entry);
+        }
+
+        return new ClassPath(path + ":" + entry);
     }
 }

--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
@@ -24,4 +24,10 @@ public class ClassPath {
             this.path += ":" + other.getClasspath();
         }
     }
+
+    public void append(String entry) {
+        if (entry != null && !entry.isEmpty()) {
+            this.path += ":" + entry;
+        }
+    }
 }

--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
@@ -18,4 +18,10 @@ public class ClassPath {
     public String getClasspath() {
         return path;
     }
+
+    public void append(ClassPath other){
+        if (other.getClasspath() != null && !other.getClasspath().isEmpty()) {
+            this.path += ":" + other.getClasspath();
+        }
+    }
 }

--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
@@ -8,7 +8,11 @@ public class ClassPath {
     }
 
     public String[] getPaths() {
-        return path.split(":");
+        if (path != null && !path.isEmpty()) {
+            return path.split(":");
+        } else {
+            return new String[0];
+        }
     }
 
     public String getClasspath() {

--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/ClassPath.java
@@ -1,0 +1,17 @@
+package de.tu_darmstadt.stg.mubench.cli;
+
+public class ClassPath {
+    private String path;
+
+    public ClassPath(String path) {
+        this.path = path;
+    }
+
+    public String[] getPaths() {
+        return path.split(":");
+    }
+
+    public String getClasspath() {
+        return path;
+    }
+}

--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgs.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgs.java
@@ -161,7 +161,7 @@ public class DetectorArgs {
     /**
      * @return a classpath referencing the dependencies of the code in the {@link #getTargetPath()}.
      */
-    public String[] getDependencyClassPath() throws FileNotFoundException {
-        return dependencyClassPath == null ? new String[0] : dependencyClassPath.split(":");
+    public ClassPath getDependencyClassPath() {
+        return dependencyClassPath == null ? new ClassPath("") : new ClassPath(dependencyClassPath);
     }
 }

--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgs.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgs.java
@@ -19,8 +19,8 @@ public class DetectorArgs {
 		String findingsFile = null;
 		String runFile = null;
 		DetectorMode detectorMode = null;
-		String correctUsageSrcPath = null;
-		String correctUsageClassPath = null;
+		String[] trainingSrcPaths = null;
+		String trainingClassPath = null;
 		String[] targetSrcPaths = null;
 		String targetClassPath = null;
 		String dependencyClassPath = null;
@@ -37,10 +37,10 @@ public class DetectorArgs {
 					runFile = next_arg;
 					break;
 				case keyTrainingSrcPath:
-					correctUsageSrcPath = next_arg;
+					trainingSrcPaths = next_arg.split(":");
 					break;
 				case keyTrainingClassPath:
-					correctUsageClassPath = next_arg;
+					trainingClassPath = next_arg;
 					break;
 				case keyTargetSrcPath:
 					targetSrcPaths = next_arg.split(":");
@@ -59,26 +59,26 @@ public class DetectorArgs {
 			}
 		}
 
-		return new DetectorArgs(findingsFile, runFile, detectorMode, correctUsageSrcPath, correctUsageClassPath, targetSrcPaths,
+		return new DetectorArgs(findingsFile, runFile, detectorMode, trainingSrcPaths, trainingClassPath, targetSrcPaths,
 				targetClassPath, dependencyClassPath);
 	}
 
 
 	private final String findingsFile;
 	private final String runInfoFile;
-	private final String correctUsageSrcPath;
-	private final String correctUsageClassPath;
+	private final String[] trainingSrcPaths;
+	private final String trainingClassPath;
 	private final String[] targetSrcPaths;
 	private final String targetClassPath;
 	private final String dependencyClassPath;
 	private final DetectorMode detectorMode;
 
-	DetectorArgs(String findingsFile, String runInfoFile, DetectorMode detectorMode, String correctUsageSrcPath,
-				 String correctUsageClassPath, String[] targetSrcPaths, String targetClassPath, String dependencyClassPath) {
+	DetectorArgs(String findingsFile, String runInfoFile, DetectorMode detectorMode, String[] trainingSrcPaths,
+				 String trainingClassPath, String[] targetSrcPaths, String targetClassPath, String dependencyClassPath) {
 		this.findingsFile = findingsFile;
 		this.runInfoFile = runInfoFile;
-		this.correctUsageSrcPath = correctUsageSrcPath;
-		this.correctUsageClassPath = correctUsageClassPath;
+		this.trainingSrcPaths = trainingSrcPaths;
+		this.trainingClassPath = trainingClassPath;
 		this.targetSrcPaths = targetSrcPaths;
 		this.targetClassPath = targetClassPath;
 		this.dependencyClassPath = dependencyClassPath;
@@ -112,27 +112,29 @@ public class DetectorArgs {
 	}
 
 	/**
-	 * @return path to the source files of the correct usage for a particular misuse. Should be used to extract the
-	 * correct usages in detect-only mode.
+	 * @return paths to the source files that may be used to train the detector, i.e., the path to the correct usage in
+     * detect-only mode. No training data is provided in mine-and-detect mode. Here, {@link #getTargetSrcPaths()} should
+     * be used for training instead.
 	 * @throws FileNotFoundException if the path was not provided in the runner invocation, e.g., if the runner is
 	 * invoked in mine-and-detect mode.
 	 */
-	public String getPatternSrcPath() throws FileNotFoundException {
-		if (correctUsageSrcPath == null)
-			throw new FileNotFoundException("training source path not provided");
-		return correctUsageSrcPath;
+	public String[] getTrainingSrcPaths() throws FileNotFoundException {
+		if (trainingSrcPaths == null)
+			throw new FileNotFoundException("no training source path provided");
+		return trainingSrcPaths;
 	}
 
 	/**
-	 * @return path to the class files of the correct usages for a particular misuse. Should be used to extract the
-	 * correct usages in detect-only mode.
+	 * @return path to the class files that may be used to train the detector, i.e., the path to the correct usage in
+     * detect-only mode. No training data is provided in mine-and-detect mode. Here, {@link #getTargetClassPath()}
+     * should be used for training instead.
 	 * @throws FileNotFoundException if the path was not provided in the runner invocation, e.g., if the runner is
 	 * invoked in mine-and-detect mode.
 	 */
-	public ClassPath getPatternClassPath() throws FileNotFoundException {
-		if (correctUsageClassPath == null)
-			throw new FileNotFoundException("training classpath not provided");
-		return new ClassPath(correctUsageClassPath);
+	public ClassPath getTrainingClassPath() throws FileNotFoundException {
+		if (trainingClassPath == null)
+			throw new FileNotFoundException("no training classpath provided");
+		return new ClassPath(trainingClassPath);
 	}
 
 
@@ -143,7 +145,7 @@ public class DetectorArgs {
 	 */
 	public String[] getTargetSrcPaths() throws FileNotFoundException {
 		if (targetSrcPaths == null)
-			throw new FileNotFoundException("target source path not provided");
+			throw new FileNotFoundException("no target source path provided");
 		return targetSrcPaths;
 	}
 
@@ -154,12 +156,13 @@ public class DetectorArgs {
 	 */
 	public ClassPath getTargetClassPath() throws FileNotFoundException {
 		if (targetClassPath == null)
-			throw new FileNotFoundException("target classpath not provided");
+			throw new FileNotFoundException("no target classpath provided");
 		return new ClassPath(targetClassPath);
 	}
 
     /**
-     * @return a classpath referencing the dependencies of the code in the {@link #getTargetPath()}.
+     * @return a classpath referencing the dependencies of the target code
+     * ({@link #getTargetSrcPaths()}/{@link #getTargetClassPath()}).
      */
     public ClassPath getDependencyClassPath() {
         return dependencyClassPath == null ? new ClassPath("") : new ClassPath(dependencyClassPath);

--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgs.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgs.java
@@ -22,7 +22,7 @@ public class DetectorArgs {
 		String correctUsageSrcPath = null;
 		String correctUsageClassPath = null;
 		String[] targetSrcPaths = null;
-		String[] targetClassPaths = null;
+		String targetClassPath = null;
 		String dependencyClassPath = null;
 
 		for (int i = 0; i < args.length; i += 2) {
@@ -46,7 +46,7 @@ public class DetectorArgs {
 					targetSrcPaths = next_arg.split(":");
 					break;
 				case keyTargetClassPath:
-					targetClassPaths = next_arg.split(":");
+					targetClassPath = next_arg;
 					break;
 				case keyDependenciesClassPath:
 					dependencyClassPath = next_arg;
@@ -60,7 +60,7 @@ public class DetectorArgs {
 		}
 
 		return new DetectorArgs(findingsFile, runFile, detectorMode, correctUsageSrcPath, correctUsageClassPath, targetSrcPaths,
-				targetClassPaths, dependencyClassPath);
+				targetClassPath, dependencyClassPath);
 	}
 
 
@@ -69,18 +69,18 @@ public class DetectorArgs {
 	private final String correctUsageSrcPath;
 	private final String correctUsageClassPath;
 	private final String[] targetSrcPaths;
-	private final String[] targetClassPaths;
+	private final String targetClassPath;
 	private final String dependencyClassPath;
 	private final DetectorMode detectorMode;
 
 	DetectorArgs(String findingsFile, String runInfoFile, DetectorMode detectorMode, String correctUsageSrcPath,
-				 String correctUsageClassPath, String[] targetSrcPaths, String[] targetClassPaths, String dependencyClassPath) {
+				 String correctUsageClassPath, String[] targetSrcPaths, String targetClassPath, String dependencyClassPath) {
 		this.findingsFile = findingsFile;
 		this.runInfoFile = runInfoFile;
 		this.correctUsageSrcPath = correctUsageSrcPath;
 		this.correctUsageClassPath = correctUsageClassPath;
 		this.targetSrcPaths = targetSrcPaths;
-		this.targetClassPaths = targetClassPaths;
+		this.targetClassPath = targetClassPath;
 		this.dependencyClassPath = dependencyClassPath;
 		this.detectorMode = detectorMode;
 	}
@@ -129,10 +129,10 @@ public class DetectorArgs {
 	 * @throws FileNotFoundException if the path was not provided in the runner invocation, e.g., if the runner is
 	 * invoked in mine-and-detect mode.
 	 */
-	public String getPatternClassPath() throws FileNotFoundException {
+	public ClassPath getPatternClassPath() throws FileNotFoundException {
 		if (correctUsageClassPath == null)
 			throw new FileNotFoundException("training classpath not provided");
-		return correctUsageClassPath;
+		return new ClassPath(correctUsageClassPath);
 	}
 
 
@@ -152,10 +152,10 @@ public class DetectorArgs {
 	 * training the detector.
 	 * @throws FileNotFoundException if the paths were not provided in the runner invocation
 	 */
-	public String[] getTargetClassPaths() throws FileNotFoundException {
-		if (targetClassPaths == null)
+	public ClassPath getTargetClassPath() throws FileNotFoundException {
+		if (targetClassPath == null)
 			throw new FileNotFoundException("target classpath not provided");
-		return targetClassPaths;
+		return new ClassPath(targetClassPath);
 	}
 
     /**

--- a/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/MuBenchRunner.java
+++ b/mubench.cli/src/main/java/de/tu_darmstadt/stg/mubench/cli/MuBenchRunner.java
@@ -34,8 +34,8 @@ public final class MuBenchRunner {
     private DetectionStrategy mineAndDetectStrategy;
 
     /**
-     * @param detectOnlyStrategy Run detection in detect-only mode. Should use {@link DetectorArgs#getPatternSrcPath()}
-     *                           or {@link DetectorArgs#getPatternClassPath()} to learn correct usages and identify
+     * @param detectOnlyStrategy Run detection in detect-only mode. Should use {@link DetectorArgs#getTrainingSrcPaths()}
+     *                           or {@link DetectorArgs#getTrainingClassPath()} to learn correct usages and identify
      *                           respective violations in {@link DetectorArgs#getTargetSrcPaths()} or
      *                           {@link DetectorArgs#getTargetClassPaths()}, respectively.
      */

--- a/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
+++ b/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
@@ -23,4 +23,21 @@ public class ClassPathTest {
         ClassPath uut = new ClassPath("");
         assertArrayEquals(new String[0], uut.getPaths());
     }
+
+    @Test
+    public void appendsOtherClassPath() {
+        ClassPath uut = new ClassPath("-One more time-:-We're gonna celebrate-");
+        ClassPath other = new ClassPath("-Oh yeah, all right-:-Don't stop the dancing-");
+        String expected = "-One more time-:-We're gonna celebrate-:-Oh yeah, all right-:-Don't stop the dancing-";
+        uut.append(other);
+        assertEquals(expected, uut.getClasspath());
+    }
+
+    @Test
+    public void appendsNothingOnEmptyPath(){
+        ClassPath uut = new ClassPath("");
+        ClassPath other = new ClassPath("");
+        uut.append(other);
+        assertEquals("", uut.getClasspath());
+    }
 }

--- a/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
+++ b/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
@@ -17,4 +17,10 @@ public class ClassPathTest {
         ClassPath uut = new ClassPath("-path-:-other-path-");
         assertArrayEquals(new String[]{"-path-", "-other-path-"}, uut.getPaths());
     }
+
+    @Test
+    public void getPathsHandlesEmptyPath(){
+        ClassPath uut = new ClassPath("");
+        assertArrayEquals(new String[0], uut.getPaths());
+    }
 }

--- a/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
+++ b/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
@@ -1,0 +1,20 @@
+package de.tu_darmstadt.stg.mubench.cli;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ClassPathTest {
+    @Test
+    public void getClasspath(){
+        ClassPath uut = new ClassPath("-path-");
+        assertEquals("-path-", uut.getClasspath());
+    }
+
+    @Test
+    public void getPathsSplitsPath() {
+        ClassPath uut = new ClassPath("-path-:-other-path-");
+        assertArrayEquals(new String[]{"-path-", "-other-path-"}, uut.getPaths());
+    }
+}

--- a/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
+++ b/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
@@ -40,4 +40,20 @@ public class ClassPathTest {
         uut.append(other);
         assertEquals("", uut.getClasspath());
     }
+
+    @Test
+    public void appendsEntry() {
+        ClassPath uut = new ClassPath("-We even finish each other's-");
+        String entry = "-sandwiches.-";
+        String expected = "-We even finish each other's-:-sandwiches.-";
+        uut.append(entry);
+        assertEquals(expected, uut.getClasspath());
+    }
+
+    @Test
+    public void appendsNothingOnEmptyEntry(){
+        ClassPath uut = new ClassPath("");
+        uut.append("");
+        assertEquals("", uut.getClasspath());
+    }
 }

--- a/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
+++ b/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/ClassPathTest.java
@@ -25,35 +25,43 @@ public class ClassPathTest {
     }
 
     @Test
-    public void appendsOtherClassPath() {
+    public void joinKeepsOriginalUnchanged() {
+        ClassPath uut = new ClassPath("-path-");
+        ClassPath other = new ClassPath("-other-path-");
+        uut.join(other);
+        assertEquals("-path-", uut.getClasspath());
+    }
+
+    @Test
+    public void joinsOtherClassPath() {
         ClassPath uut = new ClassPath("-One more time-:-We're gonna celebrate-");
         ClassPath other = new ClassPath("-Oh yeah, all right-:-Don't stop the dancing-");
         String expected = "-One more time-:-We're gonna celebrate-:-Oh yeah, all right-:-Don't stop the dancing-";
-        uut.append(other);
-        assertEquals(expected, uut.getClasspath());
+        ClassPath actual = uut.join(other);
+        assertEquals(expected, actual.getClasspath());
     }
 
     @Test
-    public void appendsNothingOnEmptyPath(){
+    public void joinsNothingOnEmptyPath(){
         ClassPath uut = new ClassPath("");
         ClassPath other = new ClassPath("");
-        uut.append(other);
-        assertEquals("", uut.getClasspath());
+        ClassPath actual = uut.join(other);
+        assertEquals("", actual.getClasspath());
     }
 
     @Test
-    public void appendsEntry() {
+    public void joinsEntry() {
         ClassPath uut = new ClassPath("-We even finish each other's-");
         String entry = "-sandwiches.-";
         String expected = "-We even finish each other's-:-sandwiches.-";
-        uut.append(entry);
-        assertEquals(expected, uut.getClasspath());
+        ClassPath actual = uut.join(entry);
+        assertEquals(expected, actual.getClasspath());
     }
 
     @Test
-    public void appendsNothingOnEmptyEntry(){
+    public void joinsNothingOnEmptyEntry(){
         ClassPath uut = new ClassPath("");
-        uut.append("");
-        assertEquals("", uut.getClasspath());
+        ClassPath actual = uut.join("");
+        assertEquals("", actual.getClasspath());
     }
 }

--- a/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgsTest.java
+++ b/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgsTest.java
@@ -34,12 +34,12 @@ public class DetectorArgsTest {
 	}
 
 	@Test
-	public void parsesTrainingPath() throws FileNotFoundException {
+	public void parsesTrainingPaths() throws FileNotFoundException {
 		DetectorArgs actual = DetectorArgs.parse(
 				new String[] { DetectorArgs.keyTrainingSrcPath, "psrc", DetectorArgs.keyTrainingClassPath, "pclasspath" });
 
-        assertEquals("psrc", actual.getPatternSrcPath());
-		assertEquals("pclasspath", actual.getPatternClassPath().getClasspath());
+        assertEquals("psrc", actual.getTrainingSrcPaths()[0]);
+		assertEquals("pclasspath", actual.getTrainingClassPath().getClasspath());
 	}
 
 	@Test
@@ -94,12 +94,12 @@ public class DetectorArgsTest {
 
     @Test(expected = FileNotFoundException.class)
     public void throwsOnNoTrainingSrcPath() throws FileNotFoundException {
-        DetectorArgs.parse(new String[0]).getPatternSrcPath();
+        DetectorArgs.parse(new String[0]).getTrainingSrcPaths();
     }
 
     @Test(expected = FileNotFoundException.class)
     public void throwsOnNoTrainingClassPath() throws FileNotFoundException {
-        DetectorArgs.parse(new String[0]).getPatternClassPath();
+        DetectorArgs.parse(new String[0]).getTrainingClassPath();
     }
 
     @Test(expected = FileNotFoundException.class)

--- a/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgsTest.java
+++ b/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgsTest.java
@@ -1,6 +1,5 @@
 package de.tu_darmstadt.stg.mubench.cli;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.io.FileNotFoundException;
@@ -70,7 +69,7 @@ public class DetectorArgsTest {
 	@Test
 	public void parsesDependenciesClassPath() throws Exception {
 		DetectorArgs actual = DetectorArgs.parse(new String[]{DetectorArgs.keyDependenciesClassPath, "foo:bar"});
-		assertArrayEquals(new String[] {"foo", "bar"}, actual.getDependencyClassPath());
+		assertEquals("foo:bar", actual.getDependencyClassPath().getClasspath());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -114,8 +113,8 @@ public class DetectorArgsTest {
     }
 
     @Test
-    public void noDependencyClassPath() throws FileNotFoundException {
+    public void noDependencyClassPath() {
         DetectorArgs actual = DetectorArgs.parse(new String[0]);
-        assertArrayEquals(new String[0], actual.getDependencyClassPath());
+        assertEquals("", actual.getDependencyClassPath().getClasspath());
     }
 }

--- a/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgsTest.java
+++ b/mubench.cli/src/test/java/de/tu_darmstadt/stg/mubench/cli/DetectorArgsTest.java
@@ -40,7 +40,7 @@ public class DetectorArgsTest {
 				new String[] { DetectorArgs.keyTrainingSrcPath, "psrc", DetectorArgs.keyTrainingClassPath, "pclasspath" });
 
         assertEquals("psrc", actual.getPatternSrcPath());
-		assertEquals("pclasspath", actual.getPatternClassPath());
+		assertEquals("pclasspath", actual.getPatternClassPath().getClasspath());
 	}
 
 	@Test
@@ -49,9 +49,9 @@ public class DetectorArgsTest {
 				.parse(new String[] { DetectorArgs.keyTargetSrcPath, "msrc", DetectorArgs.keyTargetClassPath, "mclasspath" });
 
         String[] targetSrcPaths = actual.getTargetSrcPaths();
-        String[] targetClassPaths = actual.getTargetClassPaths();
+        ClassPath targetClassPaths = actual.getTargetClassPath();
         assertEquals("msrc", targetSrcPaths[0]);
-		assertEquals("mclasspath", targetClassPaths[0]);
+		assertEquals("mclasspath", targetClassPaths.getClasspath());
 	}
 
 	@Test
@@ -61,11 +61,10 @@ public class DetectorArgsTest {
                                       DetectorArgs.keyTargetClassPath, "mclasspath1:mclasspath2" });
 
         String[] targetSrcPaths = actual.getTargetSrcPaths();
-        String[] targetClassPaths = actual.getTargetClassPaths();
+        ClassPath targetClassPath = actual.getTargetClassPath();
         assertEquals("msrc1", targetSrcPaths[0]);
         assertEquals("msrc2", targetSrcPaths[1]);
-        assertEquals("mclasspath1", targetClassPaths[0]);
-        assertEquals("mclasspath2", targetClassPaths[1]);
+        assertEquals("mclasspath1:mclasspath2", targetClassPath.getClasspath());
     }
 
 	@Test
@@ -111,7 +110,7 @@ public class DetectorArgsTest {
 
     @Test(expected = FileNotFoundException.class)
     public void throwsOnNoTargetClassPath() throws FileNotFoundException {
-        DetectorArgs.parse(new String[0]).getTargetClassPaths();
+        DetectorArgs.parse(new String[0]).getTargetClassPath();
     }
 
     @Test


### PR DESCRIPTION
The CLI version is not updated since I didn't know if you want a release for this. Didn't add a new detector interface on the python side for the same reason.

We're handling empty inputs as well. This might be overkill, but I thought it would be better to make sure nothing weird happens.

As discussed, we only provide the class paths as `ClassPath`. Source paths are still String arrays.