### PR TITLE
Support multiple dataset in one run

### DIFF
--- a/mubench.pipeline/benchmark.py
+++ b/mubench.pipeline/benchmark.py
@@ -26,8 +26,9 @@ class Benchmark:
         if 'black_list' in config:
             black_list.extend(config.black_list)
 
-        if 'dataset' in config:
-            white_list.extend(get_white_list(config.datasets_file_path, config.dataset))
+        if 'datasets' in config:
+            for dataset in config.datasets:
+                white_list.extend(get_white_list(config.datasets_file_path, dataset))
 
         self.data_entity_lists = DataEntityLists(white_list, black_list)
 

--- a/mubench.pipeline/tests/utils/test_config_util.py
+++ b/mubench.pipeline/tests/utils/test_config_util.py
@@ -119,13 +119,19 @@ def test_script_is_case_insensitive():
 
 def test_dataset():
     parser = _get_command_line_parser(['Dummy'], [], ['valid-dataset'])
-    result = parser.parse_args(['run', 'ex1', 'Dummy', '--dataset', 'valid-dataset'])
-    assert_equals('valid-dataset', result.dataset)
+    result = parser.parse_args(['run', 'ex1', 'Dummy', '--datasets', 'valid-dataset'])
+    assert_equals(['valid-dataset'], result.datasets)
+
+
+def test_multiple_datasets():
+    parser = _get_command_line_parser(['Dummy'], [], ['valid-dataset', 'other-valid-dataset'])
+    result = parser.parse_args(['run', 'ex1', 'Dummy', '--datasets', 'valid-dataset', 'other-valid-dataset'])
+    assert_equals(['valid-dataset', 'other-valid-dataset'], result.datasets)
 
 
 def test_fails_for_invalid_dataset():
     parser = _get_command_line_parser(['valid-detector'], [], ['valid-dataset'])
-    assert_raises(SystemExit, parser.parse_args, ['run', 'ex1', 'valid-detector', '--dataset', 'invalid-dataset'])
+    assert_raises(SystemExit, parser.parse_args, ['run', 'ex1', 'valid-detector', '--datasets', 'invalid-dataset'])
 
 
 def test_release():

--- a/mubench.pipeline/utils/config_util.py
+++ b/mubench.pipeline/utils/config_util.py
@@ -331,7 +331,7 @@ def __setup_filter_arguments(parser: ArgumentParser, available_datasets: List[st
     parser.add_argument('--skip', metavar='Y', nargs='+', dest='black_list', default=__get_default('skip', []),
                         help="skip all projects or project versions whose names are given")
     parser.add_argument('--datasets', metavar='DATASETS', nargs='+', dest='datasets',
-                        default=__get_default('datasets', None), choices=available_datasets,
+                        default=__get_default('datasets', []), choices=available_datasets,
                         help="process only misuses in the specified data set(s)")
 
 

--- a/mubench.pipeline/utils/config_util.py
+++ b/mubench.pipeline/utils/config_util.py
@@ -330,8 +330,9 @@ def __setup_filter_arguments(parser: ArgumentParser, available_datasets: List[st
                         help="process only projects or project versions whose names are given")
     parser.add_argument('--skip', metavar='Y', nargs='+', dest='black_list', default=__get_default('skip', []),
                         help="skip all projects or project versions whose names are given")
-    parser.add_argument('--dataset', metavar='DATASET', dest='dataset', default=__get_default('dataset', None),
-                        choices=available_datasets, help="process only misuses in the specified data set")
+    parser.add_argument('--datasets', metavar='DATASETS', nargs='+', dest='datasets',
+                        default=__get_default('datasets', None), choices=available_datasets,
+                        help="process only misuses in the specified data set(s)")
 
 
 def __setup_checkout_arguments(parser: ArgumentParser) -> None:


### PR DESCRIPTION
Implements #235: Support multiple dataset in one run

By the way, you can add other misuses to a dataset using `--only`. It's a bit unintuitive, but extend the white list with the given datasets.