### PR TITLE
Print "patterns already compiled" only if misuse has patterns

### DIFF
--- a/mubench.pipeline/tasks/implementations/compile_misuse.py
+++ b/mubench.pipeline/tasks/implementations/compile_misuse.py
@@ -46,8 +46,7 @@ class CompileMisuseTask:
                                                     misuse_compile.pattern_classes_path,
                                                     version_compile.get_full_classpath())
                 misuse_compile.save(self.run_timestamp)
-            else:
-                if misuse.patterns:
+            elif misuse.patterns:
                     logger.info("Correct usage already compiled.")
         except Exception:
             misuse_compile.delete()

--- a/mubench.pipeline/tasks/implementations/compile_misuse.py
+++ b/mubench.pipeline/tasks/implementations/compile_misuse.py
@@ -47,7 +47,7 @@ class CompileMisuseTask:
                                                     version_compile.get_full_classpath())
                 misuse_compile.save(self.run_timestamp)
             elif misuse.patterns:
-                    logger.info("Correct usage already compiled.")
+                logger.info("Correct usage already compiled.")
         except Exception:
             misuse_compile.delete()
             raise

--- a/mubench.pipeline/tasks/implementations/compile_misuse.py
+++ b/mubench.pipeline/tasks/implementations/compile_misuse.py
@@ -47,7 +47,8 @@ class CompileMisuseTask:
                                                     version_compile.get_full_classpath())
                 misuse_compile.save(self.run_timestamp)
             else:
-                logger.info("Correct usage already compiled.")
+                if misuse.patterns:
+                    logger.info("Correct usage already compiled.")
         except Exception:
             misuse_compile.delete()
             raise


### PR DESCRIPTION
Resolve #256: Misuse compile says "patterns already compiled" when there are no patterns