### PR TITLE
Use detectors' `startline` to find snippets

### DIFF
--- a/mubench.pipeline/data/finding.py
+++ b/mubench.pipeline/data/finding.py
@@ -44,8 +44,11 @@ class Finding(Dict[str, str]):
     def __method(self):
         return self.get("method", "")
 
+    def __startline(self):
+        return self.get("startline", -1)
+
     def get_snippets(self, source_base_paths: List[str]) -> List[Snippet]:
-        return get_snippets(source_base_paths, self.__file(), self.__method())
+        return get_snippets(source_base_paths, self.__file(), self.__method(), self.__startline())
 
 
 class SpecializedFinding(Finding):

--- a/mubench.pipeline/tests/data/test_finding.py
+++ b/mubench.pipeline/tests/data/test_finding.py
@@ -118,3 +118,12 @@ class TestTargetCode:
         snippets = finding.get_snippets(["/base"])
 
         assert_equals([], snippets)
+
+    def test_filters_by_startline(self, utils_mock):
+        utils_mock.return_value = "42:T:t-code\n===\n32:A:a\nb\nc\n===\n22:N:n-code"
+
+        finding = Finding({"file": "-file-", "method": "-method-", "startline": 33})
+
+        snippets = finding.get_snippets(["/base"])
+
+        assert_equals([Snippet("class A {\na\nb\nc\n}", 31)], snippets)


### PR DESCRIPTION
Implement #274: Use detectors' `startline` to find snippets.