### PR TITLE
Make misuse locations more precise

### DIFF
--- a/mubench.pipeline/data/misuse.py
+++ b/mubench.pipeline/data/misuse.py
@@ -11,16 +11,16 @@ from data.snippets import get_snippets, Snippet
 
 
 class Location:
-    def __init__(self, file: str, method: str, startline: int):
+    def __init__(self, file: str, method: str, line: int):
         self.file = file
         self.method = method
-        self.startline = startline
+        self.line = line
 
     def __str__(self):
         return "Location({}, {})".format(self.file, self.method)
 
     def __eq__(self, other):
-        return self.file == other.file and self.method == other.method and self.startline == other.startline
+        return self.file == other.file and self.method == other.method and self.line == other.line
 
 
 class Fix:
@@ -84,7 +84,7 @@ class Misuse:
     def location(self) -> Location:
         if not self.__location:
             location = self._yaml["location"]
-            self.__location = Location(location.get("file", ""), location.get("method", ""), location.get("startline", -1))
+            self.__location = Location(location.get("file", ""), location.get("method", ""), location.get("line", -1))
         return self.__location
 
     @property
@@ -128,7 +128,7 @@ class Misuse:
         return self._characteristics
 
     def get_snippets(self, source_base_paths: List[str]) -> List[Snippet]:
-        return get_snippets(source_base_paths, self.location.file, self.location.method, self.location.startline)
+        return get_snippets(source_base_paths, self.location.file, self.location.method, self.location.line)
 
     def get_misuse_compile(self, base_path: str) -> MisuseCompile:
         return MisuseCompile(join(base_path, self.project_id, "misuses", self.misuse_id), self.patterns)

--- a/mubench.pipeline/data/misuse.py
+++ b/mubench.pipeline/data/misuse.py
@@ -11,15 +11,16 @@ from data.snippets import get_snippets, Snippet
 
 
 class Location:
-    def __init__(self, file: str, method: str):
+    def __init__(self, file: str, method: str, startline: int):
         self.file = file
         self.method = method
+        self.startline = startline
 
     def __str__(self):
         return "Location({}, {})".format(self.file, self.method)
 
     def __eq__(self, other):
-        return self.file == other.file and self.method == other.method
+        return self.file == other.file and self.method == other.method and self.startline == other.startline
 
 
 class Fix:
@@ -83,7 +84,7 @@ class Misuse:
     def location(self) -> Location:
         if not self.__location:
             location = self._yaml["location"]
-            self.__location = Location(location.get("file", ""), location.get("method", ""))
+            self.__location = Location(location.get("file", ""), location.get("method", ""), location.get("startline", -1))
         return self.__location
 
     @property
@@ -127,7 +128,7 @@ class Misuse:
         return self._characteristics
 
     def get_snippets(self, source_base_paths: List[str]) -> List[Snippet]:
-        return get_snippets(source_base_paths, self.location.file, self.location.method)
+        return get_snippets(source_base_paths, self.location.file, self.location.method, self.location.startline)
 
     def get_misuse_compile(self, base_path: str) -> MisuseCompile:
         return MisuseCompile(join(base_path, self.project_id, "misuses", self.misuse_id), self.patterns)

--- a/mubench.pipeline/tests/data/test_misuse.py
+++ b/mubench.pipeline/tests/data/test_misuse.py
@@ -43,8 +43,8 @@ class TestMisuse:
         assert_equals(self.uut.patterns, {pattern})
 
     def test_reads_location(self):
-        uut = create_misuse('', meta={"location": {"file": "file.name", "method": "foo()"}})
-        assert_equals(Location("file.name", "foo()", -1), uut.location)
+        uut = create_misuse('', meta={"location": {"file": "file.name", "method": "foo()", "line": 42}})
+        assert_equals(Location("file.name", "foo()", 42), uut.location)
 
     def test_reads_description(self):
         misuse = create_misuse("", meta={"description": "bla bla bla"})

--- a/mubench.pipeline/tests/data/test_misuse.py
+++ b/mubench.pipeline/tests/data/test_misuse.py
@@ -44,7 +44,7 @@ class TestMisuse:
 
     def test_reads_location(self):
         uut = create_misuse('', meta={"location": {"file": "file.name", "method": "foo()"}})
-        assert_equals(Location("file.name", "foo()"), uut.location)
+        assert_equals(Location("file.name", "foo()", -1), uut.location)
 
     def test_reads_description(self):
         misuse = create_misuse("", meta={"description": "bla bla bla"})

--- a/mubench.pipeline/tests/tasks/implementations/test_publish_metadata_task.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_publish_metadata_task.py
@@ -87,7 +87,7 @@ class TestPublishMetadataTask:
             "location": {
                 "file": "/some/file.java",
                 "method": "-some.method()-",
-                "startline": -1
+                "line": -1
             },
             "target_snippets": [{"first_line_number": 42, "code": "-code-"}],
             "patterns": []

--- a/mubench.pipeline/tests/tasks/implementations/test_publish_metadata_task.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_publish_metadata_task.py
@@ -86,7 +86,8 @@ class TestPublishMetadataTask:
             ],
             "location": {
                 "file": "/some/file.java",
-                "method": "-some.method()-"
+                "method": "-some.method()-",
+                "startline": -1
             },
             "target_snippets": [{"first_line_number": 42, "code": "-code-"}],
             "patterns": []


### PR DESCRIPTION
Implement #271: Make misuse locations more precise

@salsolatragus I'm not sure what key you would like to use for `startline`, but other than that this should work now. The other question is: do you want it to be added to locations or not? I think it makes sense, but it seems to add that to the upload as well. I don't know if that's a problem.