### PR TITLE
Implement #238: Publish only run stats in Experiment 2

### DIFF
--- a/mubench.pipeline/data/detector_run.py
+++ b/mubench.pipeline/data/detector_run.py
@@ -80,6 +80,7 @@ class DetectorRun:
             return
         elif self.is_success():
             logger.info("Successful previous %s. Skipping.", self)
+            logger.info("Detector reported %s findings.", len(self.findings))
             return
 
         self.reset()
@@ -96,6 +97,8 @@ class DetectorRun:
         if not self.is_success():
             logger.info("Run {} failed.".format(str(self)))
             logger.debug("Full exception:", exc_info=True)
+        else:
+            logger.info("Detector reported %s findings.", len(self.findings))
 
     def _execute(self, detector_args: Dict[str, str], timeout: Optional[int], current_timestamp: int, logger: Logger):
         start = time.time()

--- a/mubench.pipeline/tasks/implementations/findings_filters.py
+++ b/mubench.pipeline/tasks/implementations/findings_filters.py
@@ -35,7 +35,7 @@ class PotentialHitsFilterTask:
 
 
 class AllFindingsFilterTask:
-    def __init__(self, limit: int = 0):
+    def __init__(self, limit: int):
         self.limit = limit
 
     def run(self, detector_run: DetectorRun) -> PotentialHits:
@@ -47,7 +47,4 @@ class AllFindingsFilterTask:
         return PotentialHits(potential_hits)
 
     def __get_top_findings(self, findings):
-        if self.limit:
-            return findings[0:self.limit]
-        else:
-            return findings
+        return findings[0:self.limit]

--- a/mubench.pipeline/tasks/implementations/publish_findings.py
+++ b/mubench.pipeline/tasks/implementations/publish_findings.py
@@ -44,7 +44,7 @@ class PublishFindingsTask:
                     detector, self.experiment_id, version, self.review_site_url)
 
         if detector_run.is_success():
-            logger.info("Detector reported %s potential hits.", len(potential_hits.findings))
+            logger.info("Uploading %s potential hits.", len(potential_hits.findings))
             result = "success"
         elif detector_run.is_error():
             logger.info("Detector produced an error.")

--- a/mubench.pipeline/tests/tasks/implementations/test_findings_filters.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_findings_filters.py
@@ -47,7 +47,7 @@ class TestAllFindings:
         self.detector_run = MagicMock()
         self.detector_run.detector = self.detector
 
-        self.uut = AllFindingsFilterTask()
+        self.uut = AllFindingsFilterTask(50)
 
     def test_returns_all_findings(self):
         expected = [

--- a/mubench.pipeline/tests/utils/test_config_util.py
+++ b/mubench.pipeline/tests/utils/test_config_util.py
@@ -169,3 +169,13 @@ def test_fails_without_run_subtask():
 def test_fails_without_publish_subtask():
     parser = _get_command_line_parser([], [], [])
     assert_raises(SystemExit, parser.parse_args, ['publish'])
+
+
+def test_allow_zero_limit():
+    parser = _get_command_line_parser(['DemoDetector'], [], [])
+    assert_equals(0, parser.parse_args(['publish', 'ex2', 'DemoDetector', '-s', 'site', '--limit', '0']).limit)
+
+
+def test_fails_on_negative_limit():
+    parser = _get_command_line_parser(['DemoDetector'], [], [])
+    assert_raises(SystemExit, parser.parse_args, ['publish', 'ex2', 'DemoDetector', '-s', 'site', '--limit', '-1'])

--- a/mubench.pipeline/utils/config_util.py
+++ b/mubench.pipeline/utils/config_util.py
@@ -386,7 +386,7 @@ def __setup_publish_arguments(parser: ArgumentParser) -> None:
 def __setup_publish_precision_arguments(parser: ArgumentParser) -> None:
     def upload_limit(x):
         limit = int(x)
-        if limit < 1:
+        if limit < 0:
             raise ArgumentTypeError("invalid value: {}, must be positive".format(limit))
         return limit
 

--- a/mubench.pipeline/utils/config_util.py
+++ b/mubench.pipeline/utils/config_util.py
@@ -390,5 +390,7 @@ def __setup_publish_precision_arguments(parser: ArgumentParser) -> None:
             raise ArgumentTypeError("invalid value: {}, must be positive".format(limit))
         return limit
 
-    parser.add_argument('--limit', type=upload_limit, default=__get_default('limit', 50), metavar='n', dest="limit",
-                        help="publish only the top-n findings. Defaults to 50")
+    default_limit = 50
+    parser.add_argument('--limit', type=upload_limit, default=__get_default('limit', default_limit), metavar='n',
+                        dest="limit", help="publish only the top-n findings. Defaults to {}. "
+                                           "Use `--limit 0` to publish only run stats.".format(default_limit))


### PR DESCRIPTION
Implement #238: Publish only run stats in Experiment 2 

We can now use `--limit 0`, which should filter all findings. I've also removed default handling in the filter, as we used a default of 50 and the special case for 0 was not documented anyway. In my opinion, it makes sense to always limit the potential upload size, even if the limit is very high.

I've also changed the output a bit to make this more clear. Here's an example:
```
> ./mubench publish ex2 MuDetect --limit 0 -s http://localhost --only bcel
Starting benchmark...
        All requirements satisfied. You're good to go.
        Compiling project 'bcel' version 24014e5...
        Successful previous run on project 'bcel' version 24014e5. Skipping.
        Detector reported 316 findings.
            Publishing findings of MuDetect in ex2 on project 'bcel' version 24014e5 for upload to http://localhost...
            Uploading 0 potential hits.
            ...
```