### PR TITLE
Implement #194: Update run data on republish before any reviews

### DIFF
--- a/mubench.pipeline/data/detector_run.py
+++ b/mubench.pipeline/data/detector_run.py
@@ -29,38 +29,39 @@ class DetectorRun:
         self.findings_path = findings_path
         self.__FINDINGS = None
         self.__POTENTIAL_HITS = None
-        self.__run_info = None
+        self.__RUN_INFO = None
         self._findings_file_path = join(findings_path, DetectorRun.__FINDINGS_FILE)
         self._run_file_path = join(findings_path, DetectorRun.__RUN_FILE)
 
-    def __get_run_info(self, key: str, default):
-        if not self.__run_info:
-            self.__run_info = self.__load_run_info()
-        return self.__run_info.get(key, default)
+    @property
+    def __run_info(self):
+        if not self.__RUN_INFO:
+            self.__RUN_INFO = self.__load_run_info()
+        return self.__RUN_INFO
 
     def __load_run_info(self):
         return read_yaml_if_exists(self._run_file_path)
 
     @property
     def result(self):
-        result = self.__get_run_info("result", None)
+        result = self.__run_info.get("result", None)
         return Result[result] if result else None
 
     @property
     def runtime(self):
-        return self.__get_run_info("runtime", 0)
+        return self.__run_info.get("runtime", 0)
 
     @property
     def message(self):
-        return self.__get_run_info("message", "")
+        return self.__run_info.get("message", "")
 
     @property
     def __detector_md5(self):
-        return self.__get_run_info("md5", None)
+        return self.__run_info.get("md5", None)
 
     @property
     def __timestamp(self):
-        return self.__get_run_info("timestamp", 0)
+        return self.__run_info.get("timestamp", 0)
 
     def get_run_info(self):
         run_info = {
@@ -137,7 +138,7 @@ class DetectorRun:
             "md5": detector_md5
         })
         write_yaml(run_info, file=self._run_file_path)
-        self.__run_info = run_info
+        self.__RUN_INFO = run_info
 
     @property
     def findings(self) -> List[Finding]:

--- a/mubench.pipeline/tasks/configurations/configurations.py
+++ b/mubench.pipeline/tasks/configurations/configurations.py
@@ -115,8 +115,8 @@ class PublishProvidedPatternsExperiment(TaskConfiguration):
 
     def tasks(self, config) -> List:
         filter_ = PotentialHitsFilterTask()
-        publish = PublishFindingsTask(RunProvidedPatternsExperiment.ID, config.compiles_path, config.run_timestamp,
-                                      config.review_site_url, config.review_site_user, config.review_site_password)
+        publish = PublishFindingsTask(RunProvidedPatternsExperiment.ID, config.compiles_path, config.review_site_url,
+                                      config.review_site_user, config.review_site_password)
         return RunProvidedPatternsExperiment().tasks(config) + [filter_, publish]
 
 
@@ -143,8 +143,8 @@ class PublishAllFindingsExperiment(TaskConfiguration):
 
     def tasks(self, config) -> List:
         filter_ = AllFindingsFilterTask(config.limit)
-        publish = PublishFindingsTask(RunAllFindingsExperiment.ID, config.compiles_path, config.run_timestamp,
-                                      config.review_site_url, config.review_site_user, config.review_site_password)
+        publish = PublishFindingsTask(RunAllFindingsExperiment.ID, config.compiles_path, config.review_site_url,
+                                      config.review_site_user, config.review_site_password)
         return RunAllFindingsExperiment().tasks(config) + [filter_, publish]
 
 
@@ -172,8 +172,8 @@ class PublishBenchmarkExperiment(TaskConfiguration):
     def tasks(self, config) -> List:
         collect_misuses = CollectMisusesTask()
         filter_ = PotentialHitsFilterTask()
-        publish = PublishFindingsTask(RunBenchmarkExperiment.ID, config.compiles_path, config.run_timestamp,
-                                      config.review_site_url, config.review_site_user, config.review_site_password)
+        publish = PublishFindingsTask(RunBenchmarkExperiment.ID, config.compiles_path, config.review_site_url,
+                                      config.review_site_user, config.review_site_password)
         return RunBenchmarkExperiment().tasks(config) + [collect_misuses, filter_, publish]
 
 

--- a/mubench.pipeline/tasks/implementations/publish_findings.py
+++ b/mubench.pipeline/tasks/implementations/publish_findings.py
@@ -21,14 +21,13 @@ _SNIPPETS_KEY = "target_snippets"
 
 
 class PublishFindingsTask:
-    def __init__(self, experiment_id: str, compiles_base_path: str, run_timestamp: int,
-                 review_site_url: str, review_site_user: str = "", review_site_password: str = ""):
+    def __init__(self, experiment_id: str, compiles_base_path: str, review_site_url: str, review_site_user: str = "",
+                 review_site_password: str = ""):
         super().__init__()
         self.max_files_per_post = 20  # 20 is PHP's default limit to the number of files per request
 
         self.experiment_id = experiment_id
         self.compiles_base_path = compiles_base_path
-        self.run_timestamp = run_timestamp
         self.review_site_url = review_site_url
         self.review_site_user = review_site_user
         self.review_site_password = review_site_password
@@ -92,7 +91,6 @@ class PublishFindingsTask:
         data = self._to_markdown_dict(run_info)
         data["result"] = result
         data["potential_hits"] = postable_potential_hits
-        data["timestamp"] = self.run_timestamp
 
         return data
 

--- a/mubench.pipeline/tests/data/test_detector_run.py
+++ b/mubench.pipeline/tests/data/test_detector_run.py
@@ -183,3 +183,15 @@ class TestDetectorRun:
         uut = DetectorRun(self.detector, self.version, self.findings_path)
 
         assert uut._newer_compile(compile_timestamp)
+
+    @patch("data.detector_run.DetectorRun._load_findings")
+    @patch("data.detector_run.open_yamls_if_exists")
+    def test_adds_default_info(self, read_yamls_mock, load_findings_mock, _):
+        read_yamls_mock.return_value = {}
+        load_findings_mock.return_value = []
+
+        uut = DetectorRun(self.detector, self.version, self.findings_path)
+
+        run_info = uut.get_run_info()
+
+        assert_equals({"number_of_findings": 0, "runtime": 0}, run_info)

--- a/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
@@ -30,9 +30,11 @@ class TestPublishFindingsTask:
         self.test_detector_execution.is_timeout = lambda: False
         self.test_detector_execution.runtime = 0
         self.test_detector_execution.number_of_findings = 0
+        self.test_run_timestamp = 1337
         self.test_detector_execution.get_run_info = lambda: {
             'number_of_findings': self.test_detector_execution.number_of_findings,
-            'runtime': self.test_detector_execution.runtime
+            'runtime': self.test_detector_execution.runtime,
+            'timestamp': self.test_run_timestamp
         }
         self.test_detector_execution.findings_path = "-findings-"
 
@@ -45,10 +47,7 @@ class TestPublishFindingsTask:
 
         self.test_potential_hits = PotentialHits([])
 
-        self.test_run_timestamp = 1337
-
-        self.uut = PublishFindingsTask(self.experiment_id, "/sources", self.test_run_timestamp,
-                                       "http://dummy.url", "-username-", "-password-")
+        self.uut = PublishFindingsTask(self.experiment_id, "/sources", "http://dummy.url", "-username-", "-password-")
 
     def test_post_url(self, post_mock):
         self.uut.run(self.project, self.version, self.test_detector_execution, self.test_potential_hits,
@@ -223,7 +222,7 @@ class TestPublishFindingsTask:
         self.test_detector_execution.is_success = lambda: True
         potential_hits = [self._create_finding({"list": ["hello", "world"], "dict": {"key": "value"}}, convert_mock)]
         self.test_potential_hits = PotentialHits(potential_hits)
-        self.test_detector_execution.get_run_info = lambda: {"info": {"k1": "v1"}}
+        self.test_detector_execution.get_run_info = lambda: {"info": {"k1": "v1"}, "timestamp": 0}
 
         self.uut.run(self.project, self.version, self.test_detector_execution, self.test_potential_hits,
                      self.version_compile, self.detector)


### PR DESCRIPTION
Implement #194: Update run data on republish before any reviews

@salsolatragus I'm not sure if this is what you meant. We now use the run timestamp for uploads.