### PR TITLE
Implement #291: Output start time and detector when starting run

### DIFF
--- a/mubench.pipeline/data/detector_run.py
+++ b/mubench.pipeline/data/detector_run.py
@@ -84,7 +84,7 @@ class DetectorRun:
 
         self.reset()
 
-        logger.info("Executing %s...", self)
+        logger.info("Running '%s' on %s ... (%s)", self.detector, self.version, time.strftime("%H:%M"))
 
         detector_args.update({
             key_findings_file: self._findings_file_path,


### PR DESCRIPTION
Implement #291: Output start time and detector when starting run

Now looks like this:
```
Starting benchmark...
        All requirements satisfied. You're good to go.
        Compiling project 'bcel' version 24014e5...
        Compiling misuse 'bcel.24014e5.101'...
        Compiling correct usage for misuse 'bcel.24014e5.101'...
        Correct usage already compiled.
        Running 'MuDetect' on project 'bcel' version 24014e5 ... (07:34)
        Run took 2.32 seconds.
```