### PR TITLE
Implement #51: Consider code snippets size for chunking requests

### DIFF
--- a/mubench.pipeline/tasks/implementations/publish_findings.py
+++ b/mubench.pipeline/tasks/implementations/publish_findings.py
@@ -1,12 +1,10 @@
 import getpass
 import logging
-from sys import getsizeof
+import re
+from os.path import getsize
 from typing import List, Dict
 from urllib.parse import urljoin
 
-import re
-
-from os.path import getsize
 from requests import RequestException
 
 from data.detector import Detector
@@ -83,7 +81,7 @@ class PublishFindingsTask:
         size_of_slice = 0
         for potential_hit in potential_hits:
             number_of_files_in_hit = len(potential_hit.files)
-            size_of_hit = self.__get_potential_hit_size(potential_hit)
+            size_of_hit = total_size(potential_hit)
             exceeds_max_files_per_post = number_of_files_in_slice + number_of_files_in_hit > self.max_files_per_post
             exceeds_max_post_size = size_of_slice + size_of_hit > self.max_post_size_in_bytes
             if potential_hits_slice and (exceeds_max_files_per_post or exceeds_max_post_size):
@@ -160,10 +158,6 @@ class PublishFindingsTask:
 
         return files
 
-    @staticmethod
-    def __get_potential_hit_size(potential_hit: 'SpecializedFinding') -> int:
-        return getsizeof(potential_hit) + sum([getsize(file) for file in potential_hit.files])
-
 
 class SpecializedFinding(Finding):
     def __init__(self, data: Dict[str, str], files: List[str] = None):
@@ -171,4 +165,4 @@ class SpecializedFinding(Finding):
         self.files = files or []
 
     def __sizeof__(self):
-        return total_size(self.__dict__) + total_size(self.files)
+        return total_size(self.__dict__) + sum([getsize(file) for file in self.files])

--- a/mubench.pipeline/tasks/implementations/publish_findings.py
+++ b/mubench.pipeline/tasks/implementations/publish_findings.py
@@ -26,7 +26,7 @@ class PublishFindingsTask:
                  review_site_password: str = ""):
         super().__init__()
         self.max_files_per_post = 20  # 20 is PHP's default limit to the number of files per request
-        self.max_file_size_per_post = 5000  # choose a moderate value since we only approximate upload size
+        self.max_post_size_in_bytes = 5000  # choose a moderate value since we only approximate upload size
 
         self.experiment_id = experiment_id
         self.compiles_base_path = compiles_base_path
@@ -63,7 +63,7 @@ class PublishFindingsTask:
             for potential_hit in potential_hits.findings]
 
         try:
-            for postable_potential_hits_slice in self.__slice_by_max_files_and_size_per_post(postable_potential_hits):
+            for postable_potential_hits_slice in self.__slice_by_number_of_files_and_post_size(postable_potential_hits):
                 file_paths = self.__get_file_paths(postable_potential_hits_slice)
                 postable_data = self.__to_postable_data(run_info, result, postable_potential_hits_slice)
                 self.__post(project, version, detector, postable_data, file_paths)
@@ -74,16 +74,16 @@ class PublishFindingsTask:
             else:
                 logger.error("%s", e)
 
-    def __slice_by_max_files_and_size_per_post(self, potential_hits: List['SpecializedFinding']) -> List[List[Finding]]:
+    def __slice_by_number_of_files_and_post_size(self, potential_hits: List['SpecializedFinding']) -> List[List[Finding]]:
         potential_hits_slice = []
         number_of_files_in_slice = 0
         size_of_slice = 0
         for potential_hit in potential_hits:
             number_of_files_in_hit = len(potential_hit.files)
             size_of_hit = self.__get_potential_hit_size(potential_hit)
-            file_count_limit = number_of_files_in_slice + number_of_files_in_hit > self.max_files_per_post
-            file_size_limit = size_of_slice + size_of_hit > self.max_file_size_per_post
-            if potential_hits_slice and (file_count_limit or file_size_limit):
+            exceeds_max_files_per_post = number_of_files_in_slice + number_of_files_in_hit > self.max_files_per_post
+            exceeds_max_post_size = size_of_slice + size_of_hit > self.max_post_size_in_bytes
+            if potential_hits_slice and (exceeds_max_files_per_post or exceeds_max_post_size):
                 yield potential_hits_slice
                 potential_hits_slice = [potential_hit]
                 number_of_files_in_slice = number_of_files_in_hit

--- a/mubench.pipeline/tasks/implementations/publish_findings.py
+++ b/mubench.pipeline/tasks/implementations/publish_findings.py
@@ -1,5 +1,6 @@
 import getpass
 import logging
+from sys import getsizeof
 from typing import List, Dict
 from urllib.parse import urljoin
 
@@ -25,6 +26,7 @@ class PublishFindingsTask:
                  review_site_password: str = ""):
         super().__init__()
         self.max_files_per_post = 20  # 20 is PHP's default limit to the number of files per request
+        self.max_file_size_per_post = 5000  # choose a moderate value since we only approximate upload size
 
         self.experiment_id = experiment_id
         self.compiles_base_path = compiles_base_path
@@ -61,7 +63,7 @@ class PublishFindingsTask:
             for potential_hit in potential_hits.findings]
 
         try:
-            for postable_potential_hits_slice in self.__slice_by_max_files_per_post(postable_potential_hits):
+            for postable_potential_hits_slice in self.__slice_by_max_files_and_size_per_post(postable_potential_hits):
                 file_paths = self.__get_file_paths(postable_potential_hits_slice)
                 postable_data = self.__to_postable_data(run_info, result, postable_potential_hits_slice)
                 self.__post(project, version, detector, postable_data, file_paths)
@@ -72,18 +74,24 @@ class PublishFindingsTask:
             else:
                 logger.error("%s", e)
 
-    def __slice_by_max_files_per_post(self, potential_hits: List['SpecializedFinding']) -> List[List[Finding]]:
+    def __slice_by_max_files_and_size_per_post(self, potential_hits: List['SpecializedFinding']) -> List[List[Finding]]:
         potential_hits_slice = []
         number_of_files_in_slice = 0
+        size_of_slice = 0
         for potential_hit in potential_hits:
             number_of_files_in_hit = len(potential_hit.files)
-            if number_of_files_in_slice + number_of_files_in_hit > self.max_files_per_post:
+            size_of_hit = self.__get_potential_hit_size(potential_hit)
+            file_count_limit = number_of_files_in_slice + number_of_files_in_hit > self.max_files_per_post
+            file_size_limit = size_of_slice + size_of_hit > self.max_file_size_per_post
+            if potential_hits_slice and (file_count_limit or file_size_limit):
                 yield potential_hits_slice
                 potential_hits_slice = [potential_hit]
                 number_of_files_in_slice = number_of_files_in_hit
+                size_of_slice = size_of_hit
             else:
                 potential_hits_slice.append(potential_hit)
                 number_of_files_in_slice += number_of_files_in_hit
+                size_of_slice += size_of_hit
 
         yield potential_hits_slice
 
@@ -148,6 +156,10 @@ class PublishFindingsTask:
                 files.append(replace_dot_graph_with_image(potential_hit, key, findings_path))
 
         return files
+
+    @staticmethod
+    def __get_potential_hit_size(potential_hit: 'SpecializedFinding') -> int:
+        return getsizeof(potential_hit)
 
 
 class SpecializedFinding(Finding):

--- a/mubench.pipeline/tasks/implementations/publish_findings.py
+++ b/mubench.pipeline/tasks/implementations/publish_findings.py
@@ -5,6 +5,8 @@ from typing import List, Dict
 from urllib.parse import urljoin
 
 import re
+
+from os.path import getsize
 from requests import RequestException
 
 from data.detector import Detector
@@ -160,7 +162,7 @@ class PublishFindingsTask:
 
     @staticmethod
     def __get_potential_hit_size(potential_hit: 'SpecializedFinding') -> int:
-        return getsizeof(potential_hit)
+        return getsizeof(potential_hit) + sum([getsize(file) for file in potential_hit.files])
 
 
 class SpecializedFinding(Finding):

--- a/mubench.pipeline/tasks/implementations/publish_findings.py
+++ b/mubench.pipeline/tasks/implementations/publish_findings.py
@@ -16,6 +16,7 @@ from data.project_version import ProjectVersion
 from data.snippets import SnippetUnavailableException
 from data.version_compile import VersionCompile
 from tasks.implementations.findings_filters import PotentialHits
+from utils.size import total_size
 from utils.web_util import post, as_markdown
 
 _SNIPPETS_KEY = "target_snippets"
@@ -166,3 +167,6 @@ class SpecializedFinding(Finding):
     def __init__(self, data: Dict[str, str], files: List[str] = None):
         super().__init__(data)
         self.files = files or []
+
+    def __sizeof__(self):
+        return total_size(self.__dict__) + total_size(self.files)

--- a/mubench.pipeline/tasks/implementations/publish_findings.py
+++ b/mubench.pipeline/tasks/implementations/publish_findings.py
@@ -29,7 +29,7 @@ class PublishFindingsTask:
                  review_site_password: str = ""):
         super().__init__()
         self.max_files_per_post = 20  # 20 is PHP's default limit to the number of files per request
-        self.max_post_size_in_bytes = 5000  # choose a moderate value since we only approximate upload size
+        self.max_post_size_in_bytes = 7000  # choose a moderate value since we only approximate upload size
 
         self.experiment_id = experiment_id
         self.compiles_base_path = compiles_base_path

--- a/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
@@ -276,21 +276,18 @@ class TestPublishFindingsTask:
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
     def test_publish_successful_run_in_sized_chunks(self, convert_mock, post_mock, get_potential_hit_size_mock):
-        self.uut.max_files_per_post = 100
         self.uut.max_file_size_per_post = 1500
         get_potential_hit_size_mock.return_value = 1024
         self.test_detector_execution.is_success = lambda: True
         self.test_potential_hits = PotentialHits([
-            self._create_finding({"rank": "-1-"}, convert_mock, file_paths=["-file1-"]),
-            self._create_finding({"rank": "-2-"}, convert_mock, file_paths=["-file2-"])
+            self._create_finding({"rank": "-1-"}, convert_mock),
+            self._create_finding({"rank": "-2-"}, convert_mock)
         ])
 
         self.uut.run(self.project, self.version, self.test_detector_execution, self.test_potential_hits,
                      self.version_compile, self.detector)
 
         assert_equals(len(post_mock.call_args_list), 2)
-        assert_equals(["-file1-"], post_mock.call_args_list[0][1]["file_paths"])
-        assert_equals(["-file2-"], post_mock.call_args_list[1][1]["file_paths"])
 
     def _create_finding(self, data: Dict, convert_mock=None, file_paths=None, snippets=None):
         if snippets is None:

--- a/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
@@ -289,6 +289,22 @@ class TestPublishFindingsTask:
 
         assert_equals(len(post_mock.call_args_list), 2)
 
+    @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
+    def test_add_at_least_one_hit_to_chunk(self, convert_mock, post_mock, get_potential_hit_size_mock):
+        self.uut.max_post_size_in_bytes = 0
+        self.uut.max_files_per_post = 0
+        get_potential_hit_size_mock.return_value = 1
+        self.test_detector_execution.is_success = lambda: True
+        self.test_potential_hits = PotentialHits([
+            self._create_finding({"rank": "-1-"}, convert_mock, file_paths=["-file1-"])
+        ])
+
+        self.uut.run(self.project, self.version, self.test_detector_execution, self.test_potential_hits,
+                     self.version_compile, self.detector)
+
+        assert_equals(len(post_mock.call_args_list), 1)
+        assert_equals([{"rank": "-1-", "target_snippets": []}], post_mock.call_args[0][1]["potential_hits"])
+
     def _create_finding(self, data: Dict, convert_mock=None, file_paths=None, snippets=None):
         if snippets is None:
             snippets = []

--- a/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
@@ -276,7 +276,7 @@ class TestPublishFindingsTask:
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
     def test_publish_successful_run_in_sized_chunks(self, convert_mock, post_mock, get_potential_hit_size_mock):
-        self.uut.max_file_size_per_post = 1500
+        self.uut.max_post_size_in_bytes = 1500
         get_potential_hit_size_mock.return_value = 1024
         self.test_detector_execution.is_success = lambda: True
         self.test_potential_hits = PotentialHits([

--- a/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
@@ -15,7 +15,7 @@ from tests.test_utils.data_util import create_project, create_version
 
 
 # noinspection PyAttributeOutsideInit
-@patch("tasks.implementations.publish_findings.PublishFindingsTask._PublishFindingsTask__get_potential_hit_size")
+@patch("tasks.implementations.publish_findings.PublishFindingsTask._PublishFindingsTask__get_potential_hit_size", return_value=0)
 @patch("tasks.implementations.publish_findings.post")
 class TestPublishFindingsTask:
     def setup(self):
@@ -50,8 +50,7 @@ class TestPublishFindingsTask:
 
         self.uut = PublishFindingsTask(self.experiment_id, "/sources", "http://dummy.url", "-username-", "-password-")
 
-    def test_post_url(self, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_post_url(self, post_mock, _):
         self.uut.run(self.project, self.version, self.test_detector_execution, self.test_potential_hits,
                      self.version_compile, self.detector)
 
@@ -59,8 +58,7 @@ class TestPublishFindingsTask:
             "1", self.detector.id, self.project.id, self.version.version_id), post_mock.call_args[0][0])
 
     @patch("tasks.implementations.publish_findings.getpass.getpass")
-    def test_post_auth_prompt(self, pass_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_post_auth_prompt(self, pass_mock, post_mock, _):
         pass_mock.return_value = "-password-"
 
         self.uut.run(self.project, self.version, self.test_detector_execution, self.test_potential_hits,
@@ -70,8 +68,7 @@ class TestPublishFindingsTask:
         assert_equals("-password-", post_mock.call_args[1]["password"])
 
     @patch("tasks.implementations.publish_findings.getpass.getpass")
-    def test_post_auth_provided(self, pass_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_post_auth_provided(self, pass_mock, post_mock, _):
         pass_mock.side_effect = UserWarning("should skip prompt")
         self.uut.review_site_password = "-password-"
 
@@ -82,8 +79,7 @@ class TestPublishFindingsTask:
         assert_equals("-password-", post_mock.call_args[1]["password"])
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
-    def test_publish_successful_run(self, convert_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_successful_run(self, convert_mock, post_mock, _):
         self.test_detector_execution.is_success = lambda: True
         self.test_detector_execution.runtime = 42
         self.test_detector_execution.number_of_findings = 5
@@ -108,8 +104,7 @@ class TestPublishFindingsTask:
         }, post_mock.call_args[0][1])
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
-    def test_publish_successful_run_files(self, convert_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_successful_run_files(self, convert_mock, post_mock, _):
         self.test_detector_execution.is_success = lambda: True
 
         self.test_potential_hits = PotentialHits([
@@ -123,8 +118,7 @@ class TestPublishFindingsTask:
         assert_equals(["-file1-", "-file2-"], post_mock.call_args[1]["file_paths"])
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
-    def test_publish_successful_run_in_chunks(self, convert_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_successful_run_in_chunks(self, convert_mock, post_mock, _):
         self.uut.max_files_per_post = 1
         self.test_detector_execution.is_success = lambda: True
         self.test_potential_hits = PotentialHits([
@@ -140,8 +134,7 @@ class TestPublishFindingsTask:
         assert_equals(["-file2-"], post_mock.call_args_list[1][1]["file_paths"])
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
-    def test_publish_successful_run_in_partial_chunks(self, convert_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_successful_run_in_partial_chunks(self, convert_mock, post_mock, _):
         self.uut.max_files_per_post = 3
         self.test_detector_execution.is_success = lambda: True
         self.test_potential_hits = PotentialHits([
@@ -155,8 +148,7 @@ class TestPublishFindingsTask:
         assert_equals(2, len(post_mock.call_args_list))
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
-    def test_publish_successful_run_code_snippets(self, convert_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_successful_run_code_snippets(self, convert_mock, post_mock, _):
         self.test_detector_execution.is_success = lambda: True
         self.test_potential_hits = PotentialHits(
             [self._create_finding({"rank": "42"}, convert_mock, snippets=[Snippet("-code-", 23)])])
@@ -168,8 +160,7 @@ class TestPublishFindingsTask:
                       post_mock.call_args[0][1]["potential_hits"][0]["target_snippets"])
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
-    def test_publish_successful_run_code_snippets_extraction_fails(self, convert_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_successful_run_code_snippets_extraction_fails(self, convert_mock, post_mock, _):
         self.test_detector_execution.is_success = lambda: True
         finding = self._create_finding({"rank": "42"}, convert_mock)
         finding.get_snippets = MagicMock(return_value=[])
@@ -180,8 +171,7 @@ class TestPublishFindingsTask:
 
         assert_equals([], post_mock.call_args[0][1]["potential_hits"][0]["target_snippets"])
 
-    def test_publish_erroneous_run(self, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_erroneous_run(self, post_mock, _):
         self.test_detector_execution.number_of_findings = 0
         self.test_detector_execution.is_error = lambda: True
         self.test_detector_execution.runtime = 1337
@@ -197,8 +187,7 @@ class TestPublishFindingsTask:
             "timestamp": self.test_run_timestamp
         }, post_mock.call_args[0][1])
 
-    def test_publish_timeout_run(self, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_timeout_run(self, post_mock, _):
         self.test_detector_execution.is_timeout = lambda: True
         self.test_detector_execution.runtime = 1000000
         self.test_detector_execution.number_of_findings = 0
@@ -214,8 +203,7 @@ class TestPublishFindingsTask:
             "timestamp": self.test_run_timestamp
         }, post_mock.call_args[0][1])
 
-    def test_publish_not_run(self, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_publish_not_run(self, post_mock, _):
         self.test_detector_execution.runtime = 0
         self.test_detector_execution.number_of_findings = 0
 
@@ -231,8 +219,7 @@ class TestPublishFindingsTask:
         }, post_mock.call_args[0][1])
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
-    def test_with_markdown(self, convert_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_with_markdown(self, convert_mock, post_mock, _):
         self.test_detector_execution.is_success = lambda: True
         potential_hits = [self._create_finding({"list": ["hello", "world"], "dict": {"key": "value"}}, convert_mock)]
         self.test_potential_hits = PotentialHits(potential_hits)
@@ -246,8 +233,7 @@ class TestPublishFindingsTask:
                       post_mock.call_args[0][1]["potential_hits"])
 
     @patch("tasks.implementations.publish_findings.replace_dot_graph_with_image")
-    def test_converts_graphs(self, replace_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_converts_graphs(self, replace_mock, post_mock, _):
         self.test_detector_execution.is_success = lambda: True
 
         self.test_potential_hits = PotentialHits([
@@ -268,8 +254,7 @@ class TestPublishFindingsTask:
         assert_equals([self.test_detector_execution.findings_path + "/graph"], post_mock.call_args[1]["file_paths"])
 
     @patch("tasks.implementations.publish_findings.replace_dot_graph_with_image")
-    def test_converts_directed_graphs(self, replace_mock, post_mock, getsize_mock):
-        getsize_mock.return_value = 0
+    def test_converts_directed_graphs(self, replace_mock, post_mock, _):
         self.test_detector_execution.is_success = lambda: True
 
         self.test_potential_hits = PotentialHits([
@@ -290,10 +275,10 @@ class TestPublishFindingsTask:
         assert_equals([self.test_detector_execution.findings_path + "/graph"], post_mock.call_args[1]["file_paths"])
 
     @patch("tasks.implementations.publish_findings.PublishFindingsTask._convert_graphs_to_files")
-    def test_publish_successful_run_in_sized_chunks(self, convert_mock, post_mock, getsize_mock):
+    def test_publish_successful_run_in_sized_chunks(self, convert_mock, post_mock, get_potential_hit_size_mock):
         self.uut.max_files_per_post = 100
         self.uut.max_file_size_per_post = 1500
-        getsize_mock.return_value = 1024
+        get_potential_hit_size_mock.return_value = 1024
         self.test_detector_execution.is_success = lambda: True
         self.test_potential_hits = PotentialHits([
             self._create_finding({"rank": "-1-"}, convert_mock, file_paths=["-file1-"]),

--- a/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
+++ b/mubench.pipeline/tests/tasks/implementations/test_publish_findings_task.py
@@ -15,7 +15,7 @@ from tests.test_utils.data_util import create_project, create_version
 
 
 # noinspection PyAttributeOutsideInit
-@patch("tasks.implementations.publish_findings.PublishFindingsTask._PublishFindingsTask__get_potential_hit_size", return_value=0)
+@patch("tasks.implementations.publish_findings.total_size", return_value=0)
 @patch("tasks.implementations.publish_findings.post")
 class TestPublishFindingsTask:
     def setup(self):

--- a/mubench.pipeline/tests/utils/test_size.py
+++ b/mubench.pipeline/tests/utils/test_size.py
@@ -1,0 +1,28 @@
+from sys import getsizeof
+
+from nose.tools import assert_equals
+
+from utils.size import total_size
+
+
+class TestSize:
+    class ObjectWithFixedSize:
+        def __sizeof__(self):
+            return 42
+
+    def test_size_of_object(self):
+        assert_equals(total_size(TestSize.ObjectWithFixedSize()), 42 + getsizeof(0))
+
+    def test_additional_collection_handler(self):
+        class C:
+            pass
+
+        def get_items(_):
+            get_items.called = True
+            return [TestSize.ObjectWithFixedSize()]
+
+        get_items.called = False
+
+        total_size(C(), additional_handlers={C: get_items})
+
+        assert_equals(get_items.called, True)

--- a/mubench.pipeline/utils/size.py
+++ b/mubench.pipeline/utils/size.py
@@ -12,6 +12,7 @@ __default_handlers = {tuple: iter,
                       }
 
 
+# source: https://code.activestate.com/recipes/577504/
 def total_size(o, verbose=False, handlers=None):
     """ Returns the approximate memory footprint an object and all of its contents.
 

--- a/mubench.pipeline/utils/size.py
+++ b/mubench.pipeline/utils/size.py
@@ -1,0 +1,44 @@
+from sys import getsizeof, stderr
+from itertools import chain
+from collections import deque
+
+
+__handlers = {tuple: iter,
+              list: iter,
+              deque: iter,
+              dict: lambda d: chain.from_iterable(d.items()),
+              set: iter,
+              frozenset: iter,
+              }
+
+
+def total_size(o, verbose=False):
+    """ Returns the approximate memory footprint an object and all of its contents.
+
+    Automatically finds the contents of the following builtin containers and
+    their subclasses:  tuple, list, deque, dict, set and frozenset.
+    To search other containers, add handlers to iterate over their contents:
+
+        handlers = {SomeContainerClass: iter,
+                    OtherContainerClass: OtherContainerClass.get_elements}
+
+    """
+    seen = set()  # track which object id's have already been seen
+    default_size = getsizeof(0)  # estimate sizeof object without __sizeof__
+
+    def sizeof(obj):
+        if id(obj) in seen:  # do not double count the same object
+            return 0
+        seen.add(id(obj))
+        s = getsizeof(obj, default_size)
+
+        if verbose:
+            print(s, type(obj), repr(obj), file=stderr)
+
+        for type_, handler in __handlers.items():
+            if isinstance(obj, type_):
+                s += sum(map(sizeof, handler(obj)))
+                break
+        return s
+
+    return sizeof(o)

--- a/mubench.pipeline/utils/size.py
+++ b/mubench.pipeline/utils/size.py
@@ -3,16 +3,16 @@ from itertools import chain
 from collections import deque
 
 
-__handlers = {tuple: iter,
-              list: iter,
-              deque: iter,
-              dict: lambda d: chain.from_iterable(d.items()),
-              set: iter,
-              frozenset: iter,
-              }
+__default_handlers = {tuple: iter,
+                      list: iter,
+                      deque: iter,
+                      dict: lambda d: chain.from_iterable(d.items()),
+                      set: iter,
+                      frozenset: iter,
+                      }
 
 
-def total_size(o, verbose=False):
+def total_size(o, verbose=False, handlers=None):
     """ Returns the approximate memory footprint an object and all of its contents.
 
     Automatically finds the contents of the following builtin containers and
@@ -25,6 +25,7 @@ def total_size(o, verbose=False):
     """
     seen = set()  # track which object id's have already been seen
     default_size = getsizeof(0)  # estimate sizeof object without __sizeof__
+    handlers = __default_handlers.update(handlers)
 
     def sizeof(obj):
         if id(obj) in seen:  # do not double count the same object
@@ -35,7 +36,7 @@ def total_size(o, verbose=False):
         if verbose:
             print(s, type(obj), repr(obj), file=stderr)
 
-        for type_, handler in __handlers.items():
+        for type_, handler in handlers.items():
             if isinstance(obj, type_):
                 s += sum(map(sizeof, handler(obj)))
                 break

--- a/mubench.pipeline/utils/size.py
+++ b/mubench.pipeline/utils/size.py
@@ -13,7 +13,7 @@ __default_handlers = {tuple: iter,
 
 
 # source: https://code.activestate.com/recipes/577504/
-def total_size(o, verbose=False, handlers=None):
+def total_size(o, verbose=False, additional_handlers=None):
     """ Returns the approximate memory footprint an object and all of its contents.
 
     Automatically finds the contents of the following builtin containers and
@@ -26,7 +26,9 @@ def total_size(o, verbose=False, handlers=None):
     """
     seen = set()  # track which object id's have already been seen
     default_size = getsizeof(0)  # estimate sizeof object without __sizeof__
-    handlers = __default_handlers.update(handlers)
+    handlers = dict(__default_handlers)
+    if additional_handlers:
+        handlers.update(additional_handlers)
 
     def sizeof(obj):
         if id(obj) in seen:  # do not double count the same object


### PR DESCRIPTION
Implement #51: Consider code snippets size for chunking requests

We now additionally limit the slices by potential-hit size in bytes. @salsolatragus I've set a somewhat arbitrary limit, so you'll probably want to adjust that. 