### PR TITLE
Fix  #357: Flaky test for import logic

### DIFF
--- a/mubench.reviewsite/src/Controllers/ImportRunsController.php
+++ b/mubench.reviewsite/src/Controllers/ImportRunsController.php
@@ -95,7 +95,6 @@ class ImportRunsController extends RunsController
         $this->createOrUpdateRunsTable($detector, $run->getAttributes());
         $imported_run = $this->importAndResetConnectionModel($run);
         $imported_run->setDetector($detector);
-        $imported_run->setCreatedAt($run->created_at);
         $imported_run->save();
         return $imported_run;
     }
@@ -103,6 +102,9 @@ class ImportRunsController extends RunsController
     private function importAndResetConnectionModel(Model $model){
         $imported_model = $model->replicate();
         $imported_model->setConnection('default');
+        if(array_key_exists('created_at', $model->getAttributes())){
+            $imported_model->setCreatedAt($model->created_at);
+        }
         return $imported_model;
     }
 

--- a/mubench.reviewsite/src/Controllers/ImportRunsController.php
+++ b/mubench.reviewsite/src/Controllers/ImportRunsController.php
@@ -95,6 +95,7 @@ class ImportRunsController extends RunsController
         $this->createOrUpdateRunsTable($detector, $run->getAttributes());
         $imported_run = $this->importAndResetConnectionModel($run);
         $imported_run->setDetector($detector);
+        $imported_run->setCreatedAt($run->created_at);
         $imported_run->save();
         return $imported_run;
     }

--- a/mubench.reviewsite/tests/ImportRunsControllerTest.php
+++ b/mubench.reviewsite/tests/ImportRunsControllerTest.php
@@ -87,6 +87,7 @@ class ImportRunsControllerTest extends SlimTestCase
 
         // switch dbs around, extern db is filled
         $this->addDBConnections('extern', 'default');
+        
         $importRunsController = new ImportRunsController($this->container);
         $importRunsController->importRunsFromConnection(1, '-d-', '-p-', '-v-', $this->container['capsule']->getConnection('extern'));
 

--- a/mubench.reviewsite/tests/ImportRunsControllerTest.php
+++ b/mubench.reviewsite/tests/ImportRunsControllerTest.php
@@ -80,14 +80,14 @@ class ImportRunsControllerTest extends SlimTestCase
         $this->createFullRunWithReview();
         sleep(1);
 
+        // need to fetch all parts beforehand because relation calls are still made on default connection
         $expectedRun = Run::of(Detector::find('-d-'))->in(Experiment::find(1))->where(['project_muid' => '-p-', 'version_muid' => '-v-'])->first();
-
-        // need to fetch snippets beforehand because call in Misuse class works on default connection
+        $expectedRun->setConnection('extern');
         $expectedSnippets = Snippet::all();
 
         // switch dbs around, extern db is filled
         $this->addDBConnections('extern', 'default');
-        
+
         $importRunsController = new ImportRunsController($this->container);
         $importRunsController->importRunsFromConnection(1, '-d-', '-p-', '-v-', $this->container['capsule']->getConnection('extern'));
 


### PR DESCRIPTION
'created_at' attribute is now kept when importing a run and 'update_at' will be the import timestamp.
I also added a 1 second delay to the test to make sure the create and import time are different.