### PR TITLE
Resolve  #273: Hide tags on review page before agreement

### DIFF
--- a/mubench.reviewsite/css/style.css
+++ b/mubench.reviewsite/css/style.css
@@ -233,7 +233,7 @@ table.fw {width:100%;}
 
 .misuse-tag {
     float: left;
-    margin-right: 3px;
+    margin: 0 3px 3px 0;
     padding: 4px;
     border-radius: 2px;
     background-color: gray;

--- a/mubench.reviewsite/css/style.css
+++ b/mubench.reviewsite/css/style.css
@@ -402,3 +402,11 @@ span.stats.invisible {
 #filter-menu label span {
     vertical-align: middle;
 }
+
+.remove-tag-button {
+    border:none;
+    outline:none;
+    background-color: #808080;
+    margin:0;
+    padding:0;
+}

--- a/mubench.reviewsite/js/nav-bar.js
+++ b/mubench.reviewsite/js/nav-bar.js
@@ -44,7 +44,7 @@ var simplemde = new SimpleMDE({
 
 function saveReview(v){
     var form = document.getElementById("review_form");
-    let tags = document.getElementById("misuse-tags").getElementsByTagName('span');
+    let tags = document.getElementById("misuse-tags-comment").getElementsByTagName('span');
     for(let i = 0; i < tags.length; ++i){
         let tagInput = document.createElement("input");
         tagInput.type = "hidden";

--- a/mubench.reviewsite/js/nav-bar.js
+++ b/mubench.reviewsite/js/nav-bar.js
@@ -44,6 +44,14 @@ var simplemde = new SimpleMDE({
 
 function saveReview(v){
     var form = document.getElementById("review_form");
+    let tags = document.getElementById("misuse-tags").getElementsByTagName('span');
+    for(let i = 0; i < tags.length; ++i){
+        let tagInput = document.createElement("input");
+        tagInput.type = "hidden";
+        tagInput.name = "review_tags[" + i + "]";
+        tagInput.value = tags[i].id;
+        form.appendChild(tagInput);
+    }
     var input = document.createElement("input");
     input.type = "hidden";
     input.name = "origin";

--- a/mubench.reviewsite/js/tag-util.js
+++ b/mubench.reviewsite/js/tag-util.js
@@ -1,15 +1,7 @@
-function addTag(url, misuseId, reviewerId, tagName){
-        let misuseTagsDiv = document.getElementById('misuse-tags')
+function addTag(tagName){
+        let misuseTagsDiv = document.getElementById('misuse-tags');
         if (isExistingTag(misuseTagsDiv, tagName)) {
-            let data = {
-                "tag_name": tagName,
-                "misuse_id": misuseId,
-                "reviewer_id": reviewerId
-            };
-            postJson(url, data, function(r){
-                let tag = JSON.parse(r.srcElement.responseText);
-                misuseTagsDiv.innerHTML += getTagTemplate(misuseId, tagName, tag);
-            });
+            misuseTagsDiv.innerHTML += getTagTemplate(tagName);
         }
         event.target.value = "";
 }
@@ -18,18 +10,16 @@ function isExistingTag(misuseTagsDiv, tagName){
     return misuseTagsDiv.querySelectorAll("span#" + tagName).length == 0;
 }
 
-function removeTag(url, misuseId, reviewerId, tagElement){
-    postJson(url, {"misuse_id": misuseId, "reviewer_id": reviewerId}, (r) => {
-        let misuseTagsDiv = document.getElementById('misuse-tags');
-        misuseTagsDiv.removeChild(tagElement);
-    });
+function removeTag(tagElement){
+    let misuseTagsDiv = document.getElementById('misuse-tags');
+    misuseTagsDiv.removeChild(tagElement);
 }
 
-function getTagTemplate(misuseId, tagName, tag){
+function getTagTemplate(tagName){
     let template = `
-        <div class="misuse-tag" style="background-color:${tag.color};color:${tag.fontColor};">
+        <div class="misuse-tag" style="color:white">
             <span id="${tagName}">${tagName}</span>
-            <button onclick="removeTag('${tag.removeUrl}', '${misuseId}', this.parentElement)" style="border:none;outline:none;margin:0;padding:0;background-color:${tag.color}"><i class="fa fa-trash"></i></button>
+            <button class="remove-tag-button" onclick="removeTag(this.parentElement)"><i class="fa fa-trash"></i></button>
         </div>`;
     return template;
 }

--- a/mubench.reviewsite/js/tag-util.js
+++ b/mubench.reviewsite/js/tag-util.js
@@ -1,9 +1,10 @@
-function addTag(url, misuseId, tagName){
+function addTag(url, misuseId, reviewerId, tagName){
         let misuseTagsDiv = document.getElementById('misuse-tags')
         if (isExistingTag(misuseTagsDiv, tagName)) {
             let data = {
                 "tag_name": tagName,
-                "misuse_id": misuseId
+                "misuse_id": misuseId,
+                "reviewer_id": reviewerId
             };
             postJson(url, data, function(r){
                 let tag = JSON.parse(r.srcElement.responseText);
@@ -17,8 +18,8 @@ function isExistingTag(misuseTagsDiv, tagName){
     return misuseTagsDiv.querySelectorAll("span#" + tagName).length == 0;
 }
 
-function removeTag(url, misuseId, tagElement){
-    postJson(url, {"misuse_id": misuseId}, (r) => {
+function removeTag(url, misuseId, reviewerId, tagElement){
+    postJson(url, {"misuse_id": misuseId, "reviewer_id": reviewerId}, (r) => {
         let misuseTagsDiv = document.getElementById('misuse-tags');
         misuseTagsDiv.removeChild(tagElement);
     });

--- a/mubench.reviewsite/js/tag-util.js
+++ b/mubench.reviewsite/js/tag-util.js
@@ -1,5 +1,5 @@
 function addTag(tagName){
-        let misuseTagsDiv = document.getElementById('misuse-tags');
+        let misuseTagsDiv = document.getElementById('misuse-tags-comment');
         if (isExistingTag(misuseTagsDiv, tagName)) {
             misuseTagsDiv.innerHTML += getTagTemplate(tagName);
         }
@@ -11,8 +11,9 @@ function isExistingTag(misuseTagsDiv, tagName){
 }
 
 function removeTag(tagElement){
-    let misuseTagsDiv = document.getElementById('misuse-tags');
-    misuseTagsDiv.removeChild(tagElement);
+    let misuseTagsDivComment = document.getElementById('misuse-tags-comment');
+    misuseTagsDivComment.removeChild(tagElement);
+    return false;
 }
 
 function getTagTemplate(tagName){
@@ -22,18 +23,4 @@ function getTagTemplate(tagName){
             <button class="remove-tag-button" onclick="removeTag(this.parentElement)"><i class="fa fa-trash"></i></button>
         </div>`;
     return template;
-}
-
-function postJson(url, msg, callback){
-    let request = new XMLHttpRequest();
-    request.open('POST', url, true);
-    request.setRequestHeader('Content-Type', 'application/json');
-    request.addEventListener('load', (r) => {
-        if(r.currentTarget.status == 200) {
-            callback(r);
-        }else{
-            console.log(r);
-        }
-    });
-    request.send(JSON.stringify(msg));
 }

--- a/mubench.reviewsite/setup/database_setup_utils.php
+++ b/mubench.reviewsite/setup/database_setup_utils.php
@@ -130,11 +130,11 @@ function createTables($connection)
     });
 
     echo 'Creating MisuseTag<br/>';
-    $schema->dropIfExistsAndCreateTable('misuse_tags', function (Blueprint $table) {
+    $schema->dropIfExistsAndCreateTable('review_tags', function (Blueprint $table) {
         $table->increments('id');
-        $table->integer('misuse_id');
+        $table->integer('review_id');
         $table->integer('tag_id');
-        $table->unique(['tag_id', 'misuse_id']);
+        $table->unique(['review_id', 'tag_id']);
     });
 
     $experiment1 = new \MuBench\ReviewSite\Models\Experiment;

--- a/mubench.reviewsite/src/Controllers/ImportRunsController.php
+++ b/mubench.reviewsite/src/Controllers/ImportRunsController.php
@@ -159,7 +159,7 @@ class ImportRunsController extends RunsController
         foreach ($misuse->misuse_tags as $tag) {
             $imported_tag = $this->importAndResetConnectionModel($tag);
             $imported_tag->save();
-            $tag_ids[] = $imported_tag->id;
+            $tag_ids[$imported_tag->id] = ['reviewer_id' => $imported_tag->pivot->reviewer_id];
         }
         return $tag_ids;
     }

--- a/mubench.reviewsite/src/Controllers/ImportRunsController.php
+++ b/mubench.reviewsite/src/Controllers/ImportRunsController.php
@@ -124,9 +124,6 @@ class ImportRunsController extends RunsController
             $imported_metadata->violations()->sync($violations);
         }
 
-        $tag_ids = $this->importTags($misuse);
-        $imported_misuse->misuse_tags()->sync($tag_ids);
-
         foreach ($misuse->reviews as $review) {
             $this->importReviews($review, $imported_misuse);
         }
@@ -151,17 +148,13 @@ class ImportRunsController extends RunsController
             }
             $imported_finding_review->violations()->sync($types);
         }
-    }
-
-    private function importTags($misuse): array
-    {
         $tag_ids = [];
-        foreach ($misuse->misuse_tags as $tag) {
+        foreach($review->tags as $tag){
             $imported_tag = $this->importAndResetConnectionModel($tag);
             $imported_tag->save();
-            $tag_ids[$imported_tag->id] = ['reviewer_id' => $imported_tag->pivot->reviewer_id];
+            $tag_ids[] = $imported_tag->id;
         }
-        return $tag_ids;
+        $imported_review->tags()->sync($tag_ids);
     }
 
     private function importMetadataCorrentUsagesAndViolations($misuse, $imported_metadata): array

--- a/mubench.reviewsite/src/Controllers/ReviewsController.php
+++ b/mubench.reviewsite/src/Controllers/ReviewsController.php
@@ -148,7 +148,7 @@ class ReviewsController extends Controller
             $findingReview = FindingReview::firstOrNew(['review_id' => $review->id, 'rank' => $rank]);
             $findingReview->decision = $findings_review['hit'];
             $findingReview->save();
-            $findingReview->violations()->sync(array_key_exists('violations', $findings_review) ? $findings_review['violations'] : array());
+            $findingReview->violations()->sync($findings_review['violations']);
         }
     }
 

--- a/mubench.reviewsite/src/Controllers/ReviewsController.php
+++ b/mubench.reviewsite/src/Controllers/ReviewsController.php
@@ -119,10 +119,11 @@ class ReviewsController extends Controller
         $comment = $review['review_comment'];
         $misuse_id = $review['misuse_id'];
         $hits = $review['review_hit'];
+        $tags = array_key_exists('review_tags', $review) ? $review['review_tags'] : array();
 
         $reviewer_name = $args['reviewer_name'];
         $reviewer = Reviewer::findByIdOrName($reviewer_name);
-        $this->updateOrCreateReview($misuse_id, $reviewer->id, $comment, $hits);
+        $this->updateOrCreateReview($misuse_id, $reviewer->id, $comment, $hits, $tags);
 
         if ($review["origin"] != "") {
             return $response->withRedirect("{$review["origin"]}");
@@ -137,17 +138,17 @@ class ReviewsController extends Controller
         }
     }
 
-    public function updateOrCreateReview($misuse_id, $reviewer_id, $comment, $findings_reviews_by_rank)
+    public function updateOrCreateReview($misuse_id, $reviewer_id, $comment, $findings_reviews_by_rank, $tags)
     {
         $review = Review::firstOrNew(['misuse_id' => $misuse_id, 'reviewer_id' => $reviewer_id]);
         $review->comment = $comment;
         $review->save();
-
+        TagsController::syncReviewTags($review->id, $tags);
         foreach ($findings_reviews_by_rank as $rank => $findings_review) {
             $findingReview = FindingReview::firstOrNew(['review_id' => $review->id, 'rank' => $rank]);
             $findingReview->decision = $findings_review['hit'];
             $findingReview->save();
-            $findingReview->violations()->sync($findings_review['violations']);
+            $findingReview->violations()->sync(array_key_exists('violations', $findings_review) ? $findings_review['violations'] : array());
         }
     }
 

--- a/mubench.reviewsite/src/Controllers/RunsController.php
+++ b/mubench.reviewsite/src/Controllers/RunsController.php
@@ -211,10 +211,10 @@ class RunsController extends Controller
                 }
                 $review->finding_reviews()->delete();
                 $review->reviewer()->dissociate();
+                $review->tags()->detach();
             }
             $misuse->reviews()->delete();
             $misuse->metadata()->dissociate();
-            $misuse->misuse_tags()->detach();
             foreach($misuse->snippets()->where('detector_muid', '!=', null) as $snippet){
                 $snippet->delete();
             }

--- a/mubench.reviewsite/src/Controllers/TagsController.php
+++ b/mubench.reviewsite/src/Controllers/TagsController.php
@@ -36,7 +36,6 @@ class TagsController extends Controller
 
     public function getTags(Request $request, Response $response, array $args)
     {
-        // TODO: fix tag statistics with reviews
         $tags = Tag::all();
         $results = array(1 => array(), 2 => array(), 3 => array());
         $totals = array(1 => array(), 2 => array(), 3 => array());

--- a/mubench.reviewsite/src/Controllers/TagsController.php
+++ b/mubench.reviewsite/src/Controllers/TagsController.php
@@ -41,10 +41,11 @@ class TagsController extends Controller
         $results = array(1 => array(), 2 => array(), 3 => array());
         $totals = array(1 => array(), 2 => array(), 3 => array());
         foreach($tags as $tag){
-            $tagged_misuses = $tag->misuses;
-            foreach($tagged_misuses as $misuse){
-                $results[$misuse->run->experiment_id][$misuse->detector->muid][$tag->name][] = $misuse;
-                $totals[$misuse->run->experiment_id][$tag->name][] = $misuse;
+            /** @var Review $review */
+            foreach($tag->reviews as $review){
+                $misuse = $review->misuse;
+                $results[$misuse->run->experiment_id][$misuse->detector->muid][$tag->name][$misuse->id] = $misuse;
+                $totals[$misuse->run->experiment_id][$tag->name][$misuse->id] = $misuse;
             }
         }
         foreach($totals as $key => $total){

--- a/mubench.reviewsite/src/Models/Misuse.php
+++ b/mubench.reviewsite/src/Models/Misuse.php
@@ -22,11 +22,6 @@ class Misuse extends Model
         return $this->hasMany(Review::class);
     }
 
-    public function misuse_tags()
-    {
-        return $this->belongsToMany(Tag::class, 'misuse_tags', 'misuse_id', 'tag_id')->withPivot(['reviewer_id']);
-    }
-
     public function detector()
     {
         return $this->belongsTo(Detector::class, 'detector_id', 'id');
@@ -233,18 +228,16 @@ class Misuse extends Model
         return false;
     }
 
-    public function getTags($reviewer)
+    public function getTags()
     {
         if(!$this->hasConclusiveReviewState()){
-            if(!$reviewer){
-                return new Collection;
-            }else{
-                return $this->misuse_tags->filter(function ($value, $key) use ($reviewer) {
-                    return $value->pivot->reviewer_id == $reviewer->id;
-                });
-            }
+            return new Collection;
         }else{
-            return $this->misuse_tags->unique('id');
+            $tags = new Collection;
+            foreach($this->reviews as $review){
+                $tags = $tags->merge($review->tags);
+            }
+            return $tags->unique('id');
         }
     }
 

--- a/mubench.reviewsite/src/Models/Misuse.php
+++ b/mubench.reviewsite/src/Models/Misuse.php
@@ -233,4 +233,15 @@ class Misuse extends Model
         return false;
     }
 
+    public function getTags($reviewer)
+    {
+        $misuseTags = $this->misuse_tags;
+        if(!$this->hasConclusiveReviewState()){
+            $misuseTags = $misuseTags->filter(function ($value, $key) use ($reviewer) {
+                return $value->pivot->reviewer_id == $reviewer->id;
+            });
+        }
+        return $misuseTags->unique('id');
+    }
+
 }

--- a/mubench.reviewsite/src/Models/Misuse.php
+++ b/mubench.reviewsite/src/Models/Misuse.php
@@ -235,13 +235,17 @@ class Misuse extends Model
 
     public function getTags($reviewer)
     {
-        $misuseTags = $this->misuse_tags;
         if(!$this->hasConclusiveReviewState()){
-            $misuseTags = $misuseTags->filter(function ($value, $key) use ($reviewer) {
-                return $value->pivot->reviewer_id == $reviewer->id;
-            });
+            if(!$reviewer){
+                return new Collection;
+            }else{
+                return $this->misuse_tags->filter(function ($value, $key) use ($reviewer) {
+                    return $value->pivot->reviewer_id == $reviewer->id;
+                });
+            }
+        }else{
+            return $this->misuse_tags->unique('id');
         }
-        return $misuseTags->unique('id');
     }
 
 }

--- a/mubench.reviewsite/src/Models/Misuse.php
+++ b/mubench.reviewsite/src/Models/Misuse.php
@@ -24,7 +24,7 @@ class Misuse extends Model
 
     public function misuse_tags()
     {
-        return $this->belongsToMany(Tag::class, 'misuse_tags', 'misuse_id', 'tag_id');
+        return $this->belongsToMany(Tag::class, 'misuse_tags', 'misuse_id', 'tag_id')->withPivot(['reviewer_id']);
     }
 
     public function detector()

--- a/mubench.reviewsite/src/Models/Review.php
+++ b/mubench.reviewsite/src/Models/Review.php
@@ -26,6 +26,11 @@ class Review extends Model
         return $this->belongsToMany(Tag::class, 'review_tags', 'review_id', 'tag_id');
     }
 
+    public function misuse()
+    {
+        return $this->belongsTo(Misuse::class);
+    }
+
     public function getDecision()
     {
         $decision = Decision::NO;

--- a/mubench.reviewsite/src/Models/Review.php
+++ b/mubench.reviewsite/src/Models/Review.php
@@ -3,6 +3,7 @@
 namespace MuBench\ReviewSite\Models;
 
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 class Review extends Model
@@ -18,6 +19,11 @@ class Review extends Model
     public function finding_reviews()
     {
         return $this->hasMany(FindingReview::class);
+    }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class, 'review_tags', 'review_id', 'tag_id');
     }
 
     public function getDecision()

--- a/mubench.reviewsite/src/Models/Tag.php
+++ b/mubench.reviewsite/src/Models/Tag.php
@@ -11,9 +11,9 @@ class Tag extends Model
     protected $fillable = ['name', 'color'];
     public $timestamps = false;
 
-    public function misuses()
+    public function reviews()
     {
-        return $this->belongsToMany(Misuse::class, 'misuse_tags', 'tag_id', 'misuse_id');
+        return $this->belongsToMany(Review::class, 'review_tags', 'tag_id', 'review_id');
     }
 
     public function getFontColor()

--- a/mubench.reviewsite/src/routes.php
+++ b/mubench.reviewsite/src/routes.php
@@ -61,8 +61,6 @@ $app->group('', function () use ($app, $settings) {
         $app->post('/runs', \MuBench\ReviewSite\Controllers\RunsController::class.":postRun");
         $app->post('/runs/delete', MuBench\ReviewSite\Controllers\RunsController::class.":deleteRun")->setName('private.runs.delete');
         $app->group('/misuses/{misuse_muid}', function() use ($app) {
-            $app->post('/tags', \MuBench\ReviewSite\Controllers\TagsController::class . ":postTag")->setName('private.tag.add');
-            $app->post('/tags/{tag_id}/delete', \MuBench\ReviewSite\Controllers\TagsController::class . ":removeTag")->setName('private.tag.remove');
             $app->post('/reviews/{reviewer_name}', \MuBench\ReviewSite\Controllers\ReviewsController::class . ":postReview")->setName('private.update.review');
             $app->post('/snippets', \MuBench\ReviewSite\Controllers\SnippetsController::class . ":postSnippet")->setName('private.snippet.add');
             $app->post('/snippets/{snippet_id}/delete', \MuBench\ReviewSite\Controllers\SnippetsController::class . ":deleteSnippet")->setName('private.snippet.remove');

--- a/mubench.reviewsite/templates/detector.phtml
+++ b/mubench.reviewsite/templates/detector.phtml
@@ -253,7 +253,7 @@ $columns_to_ignore = array(
                     <?php endif; ?>
                 </td>
                 <td class="<?= $style_classes ?>">
-                            <?php foreach($misuse->getTags($user) as $tag) : ?>
+                            <?php foreach($misuse->getTags() as $tag) : ?>
                                 <div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
                                     <span><?= htmlspecialchars($tag->name) ?></span>
                                 </div>

--- a/mubench.reviewsite/templates/detector.phtml
+++ b/mubench.reviewsite/templates/detector.phtml
@@ -253,15 +253,11 @@ $columns_to_ignore = array(
                     <?php endif; ?>
                 </td>
                 <td class="<?= $style_classes ?>">
-                    <?php if($misuse->hasConclusiveReviewState()) : ?>
-                        <?php if($misuse->misuse_tags): ?>
-                            <?php foreach($misuse->misuse_tags->unique('id') as $tag) : ?>
+                            <?php foreach($misuse->getTags($user) as $tag) : ?>
                                 <div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
                                     <span><?= htmlspecialchars($tag->name) ?></span>
                                 </div>
                             <?php endforeach; ?>
-                        <?php endif; ?>
-                    <?php endif; ?>
                 </td>
             </tr>
             <?php

--- a/mubench.reviewsite/templates/detector.phtml
+++ b/mubench.reviewsite/templates/detector.phtml
@@ -255,7 +255,7 @@ $columns_to_ignore = array(
                 <td class="<?= $style_classes ?>">
                     <?php if($misuse->hasConclusiveReviewState()) : ?>
                         <?php if($misuse->misuse_tags): ?>
-                            <?php foreach($misuse->misuse_tags as $tag) : ?>
+                            <?php foreach($misuse->misuse_tags->unique('id') as $tag) : ?>
                                 <div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
                                     <span><?= htmlspecialchars($tag->name) ?></span>
                                 </div>

--- a/mubench.reviewsite/templates/includes/review_modal.phtml
+++ b/mubench.reviewsite/templates/includes/review_modal.phtml
@@ -22,15 +22,6 @@ use MuBench\ReviewSite\Models\Misuse;
             <tr><td><b>Detector:</b></td><td><?= htmlspecialchars($detectorName($detector->muid)); ?></td></tr>
             <tr><td><b>Target:</b></td><td>project '<?= $markdown_parser->text($misuse->getProject()); ?>' version <?= $markdown_parser->text($misuse->getVersion()); ?></td></tr>
             <tr><td><b>Misuse:</b></td><td>misuse '<?= $markdown_parser->text($misuse->misuse_muid); ?>'</td></tr>
-            <tr><td><b>Tags:</b></td>
-                <td>
-                    <?php foreach($misuse->misuse_tags as $tag) : ?>
-                        <div class="misuse-tag">
-                            <span><?= htmlspecialchars($tag->name) ?></span>
-                        </div>
-                    <?php endforeach; ?>
-                </td>
-            </tr>
         </table>
         <h2>Reviews:</h2>
             <?php foreach($misuse->reviews as $review) : ?>
@@ -39,6 +30,15 @@ use MuBench\ReviewSite\Models\Misuse;
                     <tr>
                         <td><b>Reviewer:</b></td>
                         <td><a href="<?= $pathFor('review', array('experiment_id' => $experiment->id, 'detector_muid' => $detectorPathId($detector), 'project_muid' => $project, 'version_muid' => $version, 'misuse_muid' => $misuse->misuse_muid, 'reviewer_name' => $reviewerPathId($review->reviewer))) ?>"><?= htmlspecialchars($reviewerName($review->reviewer)) ?></a></td>
+                    </tr>
+                    <tr><td><b>Tags:</b></td>
+                        <td>
+                            <?php foreach($review->tags as $tag) : ?>
+                                <div class="misuse-tag">
+                                    <span><?= htmlspecialchars($tag->name) ?></span>
+                                </div>
+                            <?php endforeach; ?>
+                        </td>
                     </tr>
                     <tr style="padding-top:0;margin-top:0;">
                         <td><b>Decision:</b></td>

--- a/mubench.reviewsite/templates/review.phtml
+++ b/mubench.reviewsite/templates/review.phtml
@@ -106,36 +106,21 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
             <?php if($experiment->id !== 2) : ?>
                 <tr><td><b>Misuse:</b></td><td>misuse '<?= $markdown_parser->text($misuse->misuse_muid); ?>'</td></tr>
             <?php endif; ?>
-            <?php $misuse_tags = $misuse->getReview($reviewer)->tags; ?>
-            <?php if($user || $misuse_tags->count() > 0) : ?>
-                <tr>
-                <td><b>Tags:</b></td>
-                <td>
-                    <div id="misuse-tags" style="margin:0;padding:0;display:inline-block">
-                    <?php if($misuse_tags): ?>
-                        <?php foreach($misuse_tags as $tag) : ?>
-                            <div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
-                                <span id="<?= htmlspecialchars($tag->name) ?>"><?= htmlspecialchars($tag->name) ?></span>
-                                <?php if($user) : ?>
-                                    <button onclick="removeTag(this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
-                                <?php endif; ?>
-                            </div>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
-                    </div>
-                    <?php if($user) : ?>
-                            <div style="display:inline-block;height:100%;padding:4px;">
-                                    <input id="tag-input" class="tag-input" maxlength="100" list="tags" name="tag_name" placeholder="add new tag" autocomplete="off" onkeypress="if(event.key === 'Enter'){addTag(this.value)}">
-                                    <datalist id="tags">
-                                        <?php foreach($tags as $tag) : ?>
-                                            <option value="<?= htmlspecialchars($tag->name); ?>">
-                                        <?php endforeach;?>
-                                    </datalist>
-                            </div>
-                        <?php endif; ?>
-                </td>
-                </tr>
-            <?php endif; ?>
+            <?php $misuse_tags = $misuse->getReview($reviewer) ? $misuse->getReview($reviewer)->tags : array(); ?>
+            <tr>
+            <td><b>Tags:</b></td>
+            <td>
+                <div id="misuse-tags-top" style="margin:0;padding:0;display:inline-block">
+                <?php if($misuse_tags): ?>
+                    <?php foreach($misuse_tags as $tag) : ?>
+                        <div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
+                            <span id="<?= htmlspecialchars($tag->name) ?>"><?= htmlspecialchars($tag->name) ?></span>
+                        </div>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+                </div>
+            </td>
+            </tr>
         </table>
         <?php if($experiment->id !== 2) : ?>
             <h2>Misuse Details</h2>
@@ -221,7 +206,7 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
             <?php endif; ?>
         </table>
             <?php if($reviewer && $is_reviewer): ?>
-                <form id="review_form" action="<?= $pathFor('update.review', array('experiment_id' => $experiment->id, 'detector_muid' => $detectorPathId($detector), 'project_muid' => $misuse->getProject(), 'version_muid' => $misuse->getVersion(), 'misuse_muid' => $misuse->misuse_muid, 'reviewer_name' => $reviewer->name), true) ?>" method="post" target="">
+                <form id="review_form" action="<?= $pathFor('update.review', array('experiment_id' => $experiment->id, 'detector_muid' => $detectorPathId($detector), 'project_muid' => $misuse->getProject(), 'version_muid' => $misuse->getVersion(), 'misuse_muid' => $misuse->misuse_muid, 'reviewer_name' => $reviewer->name), true) ?>" onkeypress="return event.keyCode != 13;" method="post" target="">
             <?php endif; ?>
             <?php if($misuse->hasPotentialHits()) : ?>
 
@@ -363,6 +348,31 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                             <div class="comment-overlay-button" id="overlay-button" style="z-index:3"><span>This misuse was already reviewed.</span><a class="button" onclick="review(this)">review it anyways</a></div>
                         <?php endif; ?>
                         <table class="invisible">
+                            <tr>
+                                <td colspan="2">
+                                    <div style="float:left;margin-left:5px;">Tags:</div>
+                                    <div id="misuse-tags-comment">
+                                        <?php if($misuse_tags): ?>
+                                            <?php foreach($misuse_tags as $tag) : ?>
+                                                <div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
+                                                    <span id="<?= htmlspecialchars($tag->name) ?>"><?= htmlspecialchars($tag->name) ?></span>
+                                                    <button onclick="return removeTag(this.parentElement);" style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
+                                                </div>
+                                            <?php endforeach; ?>
+                                        <?php endif; ?>
+                                    </div>
+                                <td>
+                            </tr>
+                            <tr><td colspan="2">
+                                    <div style="height:100%;">
+                                        <input id="tag-input" class="tag-input" maxlength="100" list="tags" name="tag_name" placeholder="add new tag" autocomplete="off" onkeypress="if(event.key === 'Enter'){addTag(this.value)}">
+                                        <datalist id="tags">
+                                            <?php foreach($tags as $tag) : ?>
+                                                <option value="<?= htmlspecialchars($tag->name); ?>">
+                                            <?php endforeach;?>
+                                        </datalist>
+                                    </div>
+                                </td></tr>
                             <tr><td id="review_area" colspan="2" style="visibility: visible">
                                     <?php if($review) : ?>
                                         <textarea id="review_comment" name="review_comment" cols="80" rows="5"><?= htmlspecialchars($review->comment); ?></textarea>
@@ -429,7 +439,7 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                     <?php if($review): ?>
                     // fix for https://github.com/sparksuite/simplemde-markdown-editor/issues/344
                     document.getElementById("comment-area").style.display="block";
-                    simplemde.value("<?= $review->comment ?>");
+                    simplemde.value(`<?= $review->comment ?>`);
                     simplemde.codemirror.refresh();
                     document.getElementById("comment-area").style.display="none";
                     <?php endif; ?>

--- a/mubench.reviewsite/templates/review.phtml
+++ b/mubench.reviewsite/templates/review.phtml
@@ -111,8 +111,9 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                 <td><b>Tags:</b></td>
                 <td>
                     <div id="misuse-tags" style="margin:0;padding:0;display:inline-block">
-                    <?php if($misuse->misuse_tags): ?>
-                    <?php foreach($misuse->misuse_tags as $tag) : ?>
+                    <?php $misuse_tags = $misuse->getTags($reviewer); ?>
+                    <?php if($misuse_tags): ?>
+                        <?php foreach($misuse_tags as $tag) : ?>
                             <div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
                                 <span id="<?= htmlspecialchars($tag->name) ?>"><?= htmlspecialchars($tag->name) ?></span>
                                 <?php if($user) : ?>

--- a/mubench.reviewsite/templates/review.phtml
+++ b/mubench.reviewsite/templates/review.phtml
@@ -106,24 +106,18 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
             <?php if($experiment->id !== 2) : ?>
                 <tr><td><b>Misuse:</b></td><td>misuse '<?= $markdown_parser->text($misuse->misuse_muid); ?>'</td></tr>
             <?php endif; ?>
-            <?php $misuse_tags = $misuse->getTags($reviewer); ?>
+            <?php $misuse_tags = $misuse->getReview($reviewer)->tags; ?>
             <?php if($user || $misuse_tags->count() > 0) : ?>
                 <tr>
                 <td><b>Tags:</b></td>
                 <td>
                     <div id="misuse-tags" style="margin:0;padding:0;display:inline-block">
-                    <?php $misuse_tags = $misuse->getTags($reviewer); ?>
                     <?php if($misuse_tags): ?>
                         <?php foreach($misuse_tags as $tag) : ?>
                             <div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
                                 <span id="<?= htmlspecialchars($tag->name) ?>"><?= htmlspecialchars($tag->name) ?></span>
                                 <?php if($user) : ?>
-                                    <button onclick="removeTag('<?= $pathFor('tag.remove', array('experiment_id' => $experiment->id,
-                                        'detector_muid' => $detectorPathId($detector),
-                                        'project_muid' => $misuse->getProject(),
-                                        'version_muid' => $misuse->getVersion(),
-                                        'misuse_muid' => $misuse->misuse_muid,
-                                        'tag_id' => $tag->id)) ?>', '<?= $misuse->id ?>', '<?= $reviewer->id ?>', this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
+                                    <button onclick="removeTag(this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
                                 <?php endif; ?>
                             </div>
                         <?php endforeach; ?>
@@ -131,11 +125,7 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                     </div>
                     <?php if($user) : ?>
                             <div style="display:inline-block;height:100%;padding:4px;">
-                                    <input id="tag-input" class="tag-input" maxlength="100" list="tags" name="tag_name" placeholder="add new tag" autocomplete="off" onkeypress="if(event.key === 'Enter'){addTag('<?= $pathFor('tag.add', array('experiment_id' => $experiment->id,
-                                        'detector_muid' => $detectorPathId($detector),
-                                        'project_muid' => $misuse->getProject(),
-                                        'version_muid' => $misuse->getVersion(),
-                                        'misuse_muid' => $misuse->misuse_muid)) ?>', '<?= $misuse->id ?>', '<?= $reviewer->id ?>', this.value)}">
+                                    <input id="tag-input" class="tag-input" maxlength="100" list="tags" name="tag_name" placeholder="add new tag" autocomplete="off" onkeypress="if(event.key === 'Enter'){addTag(this.value)}">
                                     <datalist id="tags">
                                         <?php foreach($tags as $tag) : ?>
                                             <option value="<?= htmlspecialchars($tag->name); ?>">
@@ -373,6 +363,35 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                             <div class="comment-overlay-button" id="overlay-button" style="z-index:3"><span>This misuse was already reviewed.</span><a class="button" onclick="review(this)">review it anyways</a></div>
                         <?php endif; ?>
                         <table class="invisible">
+                            <tr><td>
+                                    <table class="invisible">
+                                        <tr><td>Tags:</td><td><div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
+                                                    <span id="<?= htmlspecialchars("Test") ?>"><?= htmlspecialchars("Test") ?></span>
+                                                    <?php if($user) : ?>
+                                                        <button onclick="removeTag('<?= $pathFor('tag.remove', array('experiment_id' => $experiment->id,
+                                                            'detector_muid' => $detectorPathId($detector),
+                                                            'project_muid' => $misuse->getProject(),
+                                                            'version_muid' => $misuse->getVersion(),
+                                                            'misuse_muid' => $misuse->misuse_muid,
+                                                            'tag_id' => $tag->id)) ?>', '<?= $misuse->id ?>', '<?= $reviewer->id ?>', this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
+                                                    <?php endif; ?>
+                                                </div>
+                                                <?php if($user) : ?>
+                                                    <div style="display:inline-block;height:100%;padding:4px;">
+                                                        <input id="tag-input" class="tag-input" maxlength="100" list="tags" name="tag_name" placeholder="add new tag" autocomplete="off" onkeypress="if(event.key === 'Enter'){addTag('<?= $pathFor('tag.add', array('experiment_id' => $experiment->id,
+                                                            'detector_muid' => $detectorPathId($detector),
+                                                            'project_muid' => $misuse->getProject(),
+                                                            'version_muid' => $misuse->getVersion(),
+                                                            'misuse_muid' => $misuse->misuse_muid)) ?>', '<?= $misuse->id ?>', '<?= $reviewer->id ?>', this.value)}">
+                                                        <datalist id="tags">
+                                                            <?php foreach($tags as $tag) : ?>
+                                                            <option value="<?= htmlspecialchars($tag->name); ?>">
+                                                                <?php endforeach;?>
+                                                        </datalist>
+                                                    </div>
+                                                <?php endif; ?></td></tr>
+                                    </table>
+                                </td></tr>
                             <tr><td id="review_area" colspan="2" style="visibility: visible">
                                     <?php if($review) : ?>
                                         <textarea id="review_comment" name="review_comment" cols="80" rows="5"><?= htmlspecialchars($review->comment); ?></textarea>

--- a/mubench.reviewsite/templates/review.phtml
+++ b/mubench.reviewsite/templates/review.phtml
@@ -363,26 +363,6 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                             <div class="comment-overlay-button" id="overlay-button" style="z-index:3"><span>This misuse was already reviewed.</span><a class="button" onclick="review(this)">review it anyways</a></div>
                         <?php endif; ?>
                         <table class="invisible">
-                            <tr><td>
-                                    <table class="invisible">
-                                        <tr><td>Tags:</td><td><div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
-                                                    <span id="<?= htmlspecialchars("Test") ?>"><?= htmlspecialchars("Test") ?></span>
-                                                    <?php if($user) : ?>
-                                                        <button onclick="removeTag(this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
-                                                    <?php endif; ?>
-                                                </div>
-                                                <?php if($user) : ?>
-                                                    <div style="display:inline-block;height:100%;padding:4px;">
-                                                        <input id="tag-input" class="tag-input" maxlength="100" list="tags" name="tag_name" placeholder="add new tag" autocomplete="off" onkeypress="if(event.key === 'Enter'){addTag(this.value)}">
-                                                        <datalist id="tags">
-                                                            <?php foreach($tags as $tag) : ?>
-                                                            <option value="<?= htmlspecialchars($tag->name); ?>">
-                                                                <?php endforeach;?>
-                                                        </datalist>
-                                                    </div>
-                                                <?php endif; ?></td></tr>
-                                    </table>
-                                </td></tr>
                             <tr><td id="review_area" colspan="2" style="visibility: visible">
                                     <?php if($review) : ?>
                                         <textarea id="review_comment" name="review_comment" cols="80" rows="5"><?= htmlspecialchars($review->comment); ?></textarea>

--- a/mubench.reviewsite/templates/review.phtml
+++ b/mubench.reviewsite/templates/review.phtml
@@ -368,21 +368,12 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                                         <tr><td>Tags:</td><td><div class="misuse-tag" style="background-color:<?= htmlspecialchars($tag->color) ?>;color:<?= htmlspecialchars($tag->getFontColor()) ?>;">
                                                     <span id="<?= htmlspecialchars("Test") ?>"><?= htmlspecialchars("Test") ?></span>
                                                     <?php if($user) : ?>
-                                                        <button onclick="removeTag('<?= $pathFor('tag.remove', array('experiment_id' => $experiment->id,
-                                                            'detector_muid' => $detectorPathId($detector),
-                                                            'project_muid' => $misuse->getProject(),
-                                                            'version_muid' => $misuse->getVersion(),
-                                                            'misuse_muid' => $misuse->misuse_muid,
-                                                            'tag_id' => $tag->id)) ?>', '<?= $misuse->id ?>', '<?= $reviewer->id ?>', this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
+                                                        <button onclick="removeTag(this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
                                                     <?php endif; ?>
                                                 </div>
                                                 <?php if($user) : ?>
                                                     <div style="display:inline-block;height:100%;padding:4px;">
-                                                        <input id="tag-input" class="tag-input" maxlength="100" list="tags" name="tag_name" placeholder="add new tag" autocomplete="off" onkeypress="if(event.key === 'Enter'){addTag('<?= $pathFor('tag.add', array('experiment_id' => $experiment->id,
-                                                            'detector_muid' => $detectorPathId($detector),
-                                                            'project_muid' => $misuse->getProject(),
-                                                            'version_muid' => $misuse->getVersion(),
-                                                            'misuse_muid' => $misuse->misuse_muid)) ?>', '<?= $misuse->id ?>', '<?= $reviewer->id ?>', this.value)}">
+                                                        <input id="tag-input" class="tag-input" maxlength="100" list="tags" name="tag_name" placeholder="add new tag" autocomplete="off" onkeypress="if(event.key === 'Enter'){addTag(this.value)}">
                                                         <datalist id="tags">
                                                             <?php foreach($tags as $tag) : ?>
                                                             <option value="<?= htmlspecialchars($tag->name); ?>">

--- a/mubench.reviewsite/templates/review.phtml
+++ b/mubench.reviewsite/templates/review.phtml
@@ -106,7 +106,7 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
             <?php if($experiment->id !== 2) : ?>
                 <tr><td><b>Misuse:</b></td><td>misuse '<?= $markdown_parser->text($misuse->misuse_muid); ?>'</td></tr>
             <?php endif; ?>
-            <?php $misuse_tags = $misuse->getTags($user); ?>
+            <?php $misuse_tags = $misuse->getTags($reviewer); ?>
             <?php if($user || $misuse_tags->count() > 0) : ?>
                 <tr>
                 <td><b>Tags:</b></td>

--- a/mubench.reviewsite/templates/review.phtml
+++ b/mubench.reviewsite/templates/review.phtml
@@ -106,7 +106,8 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
             <?php if($experiment->id !== 2) : ?>
                 <tr><td><b>Misuse:</b></td><td>misuse '<?= $markdown_parser->text($misuse->misuse_muid); ?>'</td></tr>
             <?php endif; ?>
-            <?php if($user || $misuse->misuse_tags) : ?>
+            <?php $misuse_tags = $misuse->getTags($user); ?>
+            <?php if($user || $misuse_tags->count() > 0) : ?>
                 <tr>
                 <td><b>Tags:</b></td>
                 <td>

--- a/mubench.reviewsite/templates/review.phtml
+++ b/mubench.reviewsite/templates/review.phtml
@@ -121,7 +121,7 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                                         'project_muid' => $misuse->getProject(),
                                         'version_muid' => $misuse->getVersion(),
                                         'misuse_muid' => $misuse->misuse_muid,
-                                        'tag_id' => $tag->id)) ?>', '<?= $misuse->id ?>', this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
+                                        'tag_id' => $tag->id)) ?>', '<?= $misuse->id ?>', '<?= $reviewer->id ?>', this.parentElement)"style="border:none;outline:none;background-color:<?= htmlspecialchars($tag->color) ?>;margin:0;padding:0"><i class="fa fa-trash"></i></button>
                                 <?php endif; ?>
                             </div>
                         <?php endforeach; ?>
@@ -133,7 +133,7 @@ $origin_path = $origin_path ? $origin_path : $pathFor('experiment.detector', arr
                                         'detector_muid' => $detectorPathId($detector),
                                         'project_muid' => $misuse->getProject(),
                                         'version_muid' => $misuse->getVersion(),
-                                        'misuse_muid' => $misuse->misuse_muid)) ?>', '<?= $misuse->id ?>', this.value)}">
+                                        'misuse_muid' => $misuse->misuse_muid)) ?>', '<?= $misuse->id ?>', '<?= $reviewer->id ?>', this.value)}">
                                     <datalist id="tags">
                                         <?php foreach($tags as $tag) : ?>
                                             <option value="<?= htmlspecialchars($tag->name); ?>">

--- a/mubench.reviewsite/tests/AnonymousViewExtensionTest.php
+++ b/mubench.reviewsite/tests/AnonymousViewExtensionTest.php
@@ -1,11 +1,10 @@
 <?php
 
+namespace MuBench\ReviewSite\Tests;
 
 use MuBench\ReviewSite\Models\Detector;
 use MuBench\ReviewSite\Models\Reviewer;
 use MuBench\ReviewSite\ViewExtensions\AnonymousViewExtension;
-
-require_once "SlimTestCase.php";
 
 class AnonymousViewExtensionTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/DetectorTest.php
+++ b/mubench.reviewsite/tests/DetectorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+namespace MuBench\ReviewSite\Tests;
 
 use MuBench\ReviewSite\Controllers\RunsController;
 use MuBench\ReviewSite\Models\Detector;

--- a/mubench.reviewsite/tests/ImportRunsControllerTest.php
+++ b/mubench.reviewsite/tests/ImportRunsControllerTest.php
@@ -191,7 +191,7 @@ class ImportRunsControllerTest extends SlimTestCase
         $violation = Violation::create(['name' => 'missing/call']);
         $metadataController->putMetadataCollection([$this->metadata]);
         $runsController->addRun(1, '-d-', '-p-', '-v-', $this->run_with_two_potential_hits_for_one_misuse);
-        $tagController->addTagToMisuse(1, 'test-dataset');
+        $tagController->addTagToMisuse(1, 'test-dataset', 1);
         $reviewController->updateOrCreateReview(1, $reviewer->id, '-comment-', [['hit' => 'Yes', 'violations' => [$violation->id]]]);
     }
 

--- a/mubench.reviewsite/tests/ImportRunsControllerTest.php
+++ b/mubench.reviewsite/tests/ImportRunsControllerTest.php
@@ -110,14 +110,15 @@ class ImportRunsControllerTest extends SlimTestCase
         self::assertAttributesEqualExceptUpdatedAt($expectedMisuse->findings[0], $actualMisuse->findings[0]);
         self::assertNotEmpty($actualMisuse->snippets());
         self::assertEquals($expectedSnippets, $actualMisuse->snippets());
-        self::assertNotEmpty($actualMisuse->misuse_tags);
-        self::assertEquals($expectedMisuse->misuse_tags[0]->getAttributes(), $actualMisuse->misuse_tags[0]->getAttributes());
+
         self::assertNotEmpty($actualMisuse->reviews);
         self::assertAttributesEqualExceptUpdatedAt($expectedMisuse->reviews[0], $actualMisuse->reviews[0]);
         $expectedReview = $expectedMisuse->reviews[0];
         $actualReview = $actualMisuse->reviews[0];
         self::assertEquals($expectedReview->reviewer->name, $actualReview->reviewer->name);
         self::assertNotEmpty($actualReview->finding_reviews);
+        self::assertNotEmpty($actualReview->tags);
+        self::assertEquals($expectedReview->tags[0]->getAttributes(), $actualReview->tags[0]->getAttributes());
         self::assertEquals($expectedReview->finding_reviews[0]->getAttributes(), $actualReview->finding_reviews[0]->getAttributes());
         self::assertEquals($expectedReview->finding_reviews[0]->violations[0]->getAttributes(), $actualReview->finding_reviews[0]->violations[0]->getAttributes());
     }
@@ -191,8 +192,7 @@ class ImportRunsControllerTest extends SlimTestCase
         $violation = Violation::create(['name' => 'missing/call']);
         $metadataController->putMetadataCollection([$this->metadata]);
         $runsController->addRun(1, '-d-', '-p-', '-v-', $this->run_with_two_potential_hits_for_one_misuse);
-        $tagController->addTagToMisuse(1, 'test-dataset', 1);
-        $reviewController->updateOrCreateReview(1, $reviewer->id, '-comment-', [['hit' => 'Yes', 'violations' => [$violation->id]]]);
+        $reviewController->updateOrCreateReview(1, $reviewer->id, '-comment-', [['hit' => 'Yes', 'violations' => [$violation->id]]], ['test-dataset']);
     }
 
     private static function assertAttributesEqualExceptUpdatedAt(Model $expectedModel, Model $actualModel){

--- a/mubench.reviewsite/tests/ImportRunsControllerTest.php
+++ b/mubench.reviewsite/tests/ImportRunsControllerTest.php
@@ -1,9 +1,8 @@
 <?php
 
-require_once "SlimTestCase.php";
+namespace MuBench\ReviewSite\Tests;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Schema;
 use MuBench\ReviewSite\Controllers\ImportRunsController;
 use MuBench\ReviewSite\Controllers\MetadataController;
 use MuBench\ReviewSite\Controllers\RunsController;

--- a/mubench.reviewsite/tests/MenuViewExtensionTest.php
+++ b/mubench.reviewsite/tests/MenuViewExtensionTest.php
@@ -68,7 +68,7 @@ class MenuViewExtensionTest extends SlimTestCase
 
     function testDetectorNeedsReviewGlobalNotPersonal()
     {
-        $this->reviewController->updateOrCreateReview($this->run->misuses[0]->id, $this->reviewer1->id, '-comment-', [['hit' => "Yes", 'violations' => []]]);
+        $this->reviewController->updateOrCreateReview($this->run->misuses[0]->id, $this->reviewer1->id, '-comment-', [['hit' => "Yes", 'violations' => []]], []);
 
         $menuViewExntesion = new MenuViewExtension($this->container);
         $review_states = $menuViewExntesion->getReviewStates($this->experiment, $this->detector, 20, $this->reviewer1);
@@ -93,8 +93,8 @@ class MenuViewExtensionTest extends SlimTestCase
 
     private function reviewMisuse($reviewer1_decision, $reviewer2_decision)
     {
-        $this->reviewController->updateOrCreateReview($this->run->misuses[0]->id, $this->reviewer1->id, '-comment-', [['hit' => $reviewer1_decision, 'violations' => []]]);
-        $this->reviewController->updateOrCreateReview($this->run->misuses[0]->id, $this->reviewer2->id, '-comment-', [['hit' => $reviewer2_decision, 'violations' => []]]);
+        $this->reviewController->updateOrCreateReview($this->run->misuses[0]->id, $this->reviewer1->id, '-comment-', [['hit' => $reviewer1_decision, 'violations' => []]], []);
+        $this->reviewController->updateOrCreateReview($this->run->misuses[0]->id, $this->reviewer2->id, '-comment-', [['hit' => $reviewer2_decision, 'violations' => []]], []);
     }
 
 }

--- a/mubench.reviewsite/tests/MenuViewExtensionTest.php
+++ b/mubench.reviewsite/tests/MenuViewExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace MuBench\ReviewSite\Tests;
+
 use MuBench\ReviewSite\Controllers\ReviewsController;
 use MuBench\ReviewSite\Controllers\RunsController;
 use MuBench\ReviewSite\ViewExtensions\MenuViewExtension;
@@ -8,9 +10,6 @@ use MuBench\ReviewSite\Models\Experiment;
 use MuBench\ReviewSite\Models\Reviewer;
 use MuBench\ReviewSite\Models\ReviewState;
 use MuBench\ReviewSite\Models\Run;
-
-require_once "SlimTestCase.php";
-
 
 class MenuViewExtensionTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/MetadataControllerTest.php
+++ b/mubench.reviewsite/tests/MetadataControllerTest.php
@@ -1,14 +1,13 @@
 <?php
 
-namespace MuBench\ReviewSite\Controllers;
+namespace MuBench\ReviewSite\Tests;
 
-require_once "SlimTestCase.php";
-
+use MuBench\ReviewSite\Controllers\MetadataController;
+use MuBench\ReviewSite\Controllers\RunsController;
 use MuBench\ReviewSite\Models\Detector;
 use MuBench\ReviewSite\Models\Experiment;
 use MuBench\ReviewSite\Models\Metadata;
 use MuBench\ReviewSite\Models\Run;
-use SlimTestCase;
 
 class MetadataControllerTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/MisuseFilterTest.php
+++ b/mubench.reviewsite/tests/MisuseFilterTest.php
@@ -1,16 +1,12 @@
 <?php
 
-namespace MuBench\ReviewSite\Controllers;
+namespace MuBench\ReviewSite\Tests;
 
-require_once 'SlimTestCase.php';
-
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
+use MuBench\ReviewSite\Controllers\RunsController;
 use MuBench\ReviewSite\Models\Detector;
 use MuBench\ReviewSite\Models\Experiment;
 use MuBench\ReviewSite\Models\Misuse;
 use MuBench\ReviewSite\Models\Reviewer;
-use SlimTestCase;
 
 class MisuseFilterTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/MisuseFilterTest.php
+++ b/mubench.reviewsite/tests/MisuseFilterTest.php
@@ -12,6 +12,8 @@ class MisuseFilterTest extends SlimTestCase
 {
     /** @var RunsController */
     private $runController;
+    /** @var ReviewsControllerHelper */
+    private $reviewControllerHelper;
     /** @var Experiment */
     private $experiment;
     /** @var Detector */
@@ -33,6 +35,7 @@ class MisuseFilterTest extends SlimTestCase
         $this->detector = Detector::create(['muid' => 'test-detector']);
 
         $this->runController = new RunsController($this->container);
+        $this->reviewControllerHelper = new ReviewsControllerHelper($this->container);
 
         $this->runController->addRun(
             $this->experiment->id,
@@ -61,7 +64,7 @@ class MisuseFilterTest extends SlimTestCase
 
     function test_counts_misuse_with_single_conclusive_review()
     {
-        $this->createReview($this->misuse, $this->reviewer1, 'Yes');
+        $this->reviewControllerHelper->createReview($this->misuse, $this->reviewer1, 'Yes');
 
         $runs = $this->runController->getRuns($this->detector, $this->experiment, 1);
 
@@ -70,8 +73,8 @@ class MisuseFilterTest extends SlimTestCase
 
     function test_counts_misuse_with_multiple_conclusive_reviews()
     {
-        $this->createReview($this->misuse, $this->reviewer1, 'Yes');
-        $this->createReview($this->misuse, $this->reviewer2, 'Yes');
+        $this->reviewControllerHelper->createReview($this->misuse, $this->reviewer1, 'Yes');
+        $this->reviewControllerHelper->createReview($this->misuse, $this->reviewer2, 'Yes');
 
         $runs = $this->runController->getRuns($this->detector, $this->experiment, 1);
 
@@ -80,7 +83,7 @@ class MisuseFilterTest extends SlimTestCase
 
     function test_ignores_misuse_with_single_inconclusive_review()
     {
-        $this->createReview($this->misuse, $this->reviewer1, '?');
+        $this->reviewControllerHelper->createReview($this->misuse, $this->reviewer1, '?');
 
         $runs = $this->runController->getRuns($this->detector, $this->experiment, 1);
 
@@ -89,8 +92,8 @@ class MisuseFilterTest extends SlimTestCase
 
     function test_ignores_misuse_with_at_least_one_inconclusive_review()
     {
-        $this->createReview($this->misuse, $this->reviewer1, '?');
-        $this->createReview($this->misuse, $this->reviewer2, 'Yes');
+        $this->reviewControllerHelper->createReview($this->misuse, $this->reviewer1, '?');
+        $this->reviewControllerHelper->createReview($this->misuse, $this->reviewer2, 'Yes');
 
         $runs = $this->runController->getRuns($this->detector, $this->experiment, 1);
 

--- a/mubench.reviewsite/tests/MisuseFilterTest.php
+++ b/mubench.reviewsite/tests/MisuseFilterTest.php
@@ -8,13 +8,12 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use MuBench\ReviewSite\Models\Detector;
 use MuBench\ReviewSite\Models\Experiment;
+use MuBench\ReviewSite\Models\Misuse;
 use MuBench\ReviewSite\Models\Reviewer;
 use SlimTestCase;
 
 class MisuseFilterTest extends SlimTestCase
 {
-    /** @var ReviewsController */
-    private $reviewController;
     /** @var RunsController */
     private $runController;
     /** @var Experiment */
@@ -25,16 +24,8 @@ class MisuseFilterTest extends SlimTestCase
     private $reviewer1;
     /** @var Reviewer */
     private $reviewer2;
-
-    private $undecided_review = [
-        'hit' => '?',
-        'violations' => []
-    ];
-
-    private $decided_review = [
-        'hit' => 'Yes',
-        'violations' => []
-    ];
+    /** @var Misuse */
+    private $misuse;
 
     function setUp()
     {
@@ -46,7 +37,6 @@ class MisuseFilterTest extends SlimTestCase
         $this->detector = Detector::create(['muid' => 'test-detector']);
 
         $this->runController = new RunsController($this->container);
-        $this->reviewController = new ReviewsController($this->container);
 
         $this->runController->addRun(
             $this->experiment->id,
@@ -63,6 +53,7 @@ class MisuseFilterTest extends SlimTestCase
                     ['misuse' => '2', 'rank' => 2, 'file' => '-foo.java-', 'target_snippets' => []]
                 ]
             ]);
+        $this->misuse = Misuse::find(1);
     }
 
     function test_counts_misuse_without_reviews()
@@ -74,7 +65,7 @@ class MisuseFilterTest extends SlimTestCase
 
     function test_counts_misuse_with_single_conclusive_review()
     {
-        $this->reviewController->updateOrCreateReview('1', $this->reviewer1->id, '', [1 => $this->decided_review]);
+        $this->createReview($this->misuse, $this->reviewer1, 'Yes');
 
         $runs = $this->runController->getRuns($this->detector, $this->experiment, 1);
 
@@ -83,8 +74,8 @@ class MisuseFilterTest extends SlimTestCase
 
     function test_counts_misuse_with_multiple_conclusive_reviews()
     {
-        $this->reviewController->updateOrCreateReview('1', $this->reviewer1->id, '', [1 => $this->decided_review]);
-        $this->reviewController->updateOrCreateReview('1', $this->reviewer2->id, '', [1 => $this->decided_review]);
+        $this->createReview($this->misuse, $this->reviewer1, 'Yes');
+        $this->createReview($this->misuse, $this->reviewer2, 'Yes');
 
         $runs = $this->runController->getRuns($this->detector, $this->experiment, 1);
 
@@ -93,7 +84,7 @@ class MisuseFilterTest extends SlimTestCase
 
     function test_ignores_misuse_with_single_inconclusive_review()
     {
-        $this->reviewController->updateOrCreateReview('1', $this->reviewer1->id, '', [1 => $this->undecided_review]);
+        $this->createReview($this->misuse, $this->reviewer1, '?');
 
         $runs = $this->runController->getRuns($this->detector, $this->experiment, 1);
 
@@ -102,8 +93,8 @@ class MisuseFilterTest extends SlimTestCase
 
     function test_ignores_misuse_with_at_least_one_inconclusive_review()
     {
-        $this->reviewController->updateOrCreateReview('1', $this->reviewer1->id, '', [1 => $this->undecided_review]);
-        $this->reviewController->updateOrCreateReview('1', $this->reviewer2->id, '', [1 => $this->decided_review]);
+        $this->createReview($this->misuse, $this->reviewer1, '?');
+        $this->createReview($this->misuse, $this->reviewer2, 'Yes');
 
         $runs = $this->runController->getRuns($this->detector, $this->experiment, 1);
 

--- a/mubench.reviewsite/tests/MisuseTest.php
+++ b/mubench.reviewsite/tests/MisuseTest.php
@@ -122,32 +122,36 @@ class MisuseTest extends SlimTestCase
 
     function testGetTagsOfReviewerWhenNotConclusive()
     {
-        $this->createRunWithFindingInLine(10);
-        $reviewController = new ReviewsController($this->container);
-        $reviewController->updateOrCreateReview(1, 2, '-comment-', [['hit' => 'Yes', 'violations' => []]]);
-        $reviewController->updateOrCreateReview(1, 3, '-comment-', [['hit' => 'No', 'violations' => []]]);
-
         $reviewer1 = Reviewer::create(['name' => 'reviewer1']);
         $reviewer2 = Reviewer::create(['name' => 'reviewer2']);
 
+        $this->createRunWithFindingInLine(10);
+        $misuse = Misuse::find(1);
+
+        $this->createReview($misuse, $reviewer1, 'Yes');
+        $this->createReview($misuse, $reviewer2, 'No');
+
         $tagController = new \MuBench\ReviewSite\Controllers\TagsController($this->container);
-        $tagController->addTagToMisuse(1, 'reviewer1-tag', 2);
-        $tagController->addTagToMisuse(1, 'reviewer2-tag', 3);
-        $tags = Misuse::find(1)->getTags($reviewer1);
+        $tagController->addTagToMisuse($misuse->id, 'reviewer1-tag', $reviewer1->id);
+        $tagController->addTagToMisuse($misuse->id, 'reviewer2-tag', $reviewer2->id);
+
+        $tags = $misuse->getTags($reviewer1);
         self::assertEquals(1, $tags->count());
         self::assertEquals('reviewer1-tag', $tags[0]->name);
     }
 
     function testGetNoTagsWithoutReviewerWhenNotConclusive()
     {
+        $reviewer1 = Reviewer::create(['name' => 'reviewer1']);
         $this->createRunWithFindingInLine(10);
-        $reviewController = new ReviewsController($this->container);
-        $reviewController->updateOrCreateReview(1, 1, '-comment-', [['hit' => 'Yes', 'violations' => []]]);
+        $misuse = Misuse::find(1);
+
+        $this->createReview($misuse, $reviewer1, 'Yes');
 
         $tagController = new \MuBench\ReviewSite\Controllers\TagsController($this->container);
-        $tagController->addTagToMisuse(1, 'reviewer1-tag', 1);
+        $tagController->addTagToMisuse($misuse->id, 'reviewer1-tag', $reviewer1->id);
 
-        self::assertEquals(0, Misuse::find(1)->getTags(null)->count());
+        self::assertEquals(0, $misuse->getTags(null)->count());
     }
 
     public function createRunWithFindingInLine($line)

--- a/mubench.reviewsite/tests/MisuseTest.php
+++ b/mubench.reviewsite/tests/MisuseTest.php
@@ -108,16 +108,16 @@ class MisuseTest extends SlimTestCase
 
     function testGetAllTagsWhenConclusive()
     {
+        $reviewer1 = Reviewer::create(['name' => 'reviewer1']);
+        $reviewer2 = Reviewer::create(['name' => 'reviewer2']);
+
         $this->createRunWithFindingInLine(10);
-        $reviewController = new ReviewsController($this->container);
-        $reviewController->updateOrCreateReview(1, 1, '-comment-', [['hit' => 'Yes', 'violations' => []]]);
-        $reviewController->updateOrCreateReview(1, 2, '-comment-', [['hit' => 'Yes', 'violations' => []]]);
+        $misuse = Misuse::find(1);
 
-        $tagController = new \MuBench\ReviewSite\Controllers\TagsController($this->container);
-        $tagController->addTagToMisuse(1, 'reviewer1-tag', 1);
-        $tagController->addTagToMisuse(1, 'reviewer2-tag', 2);
+        $this->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
+        $this->createReview($misuse, $reviewer2, 'Yes', [], ['reviewer2-tag']);
 
-        self::assertEquals(2, Misuse::find(1)->getTags(null)->count());
+        self::assertEquals(2, Misuse::find(1)->getTags()->count());
     }
 
     function testGetTagsOfReviewerWhenNotConclusive()
@@ -128,14 +128,10 @@ class MisuseTest extends SlimTestCase
         $this->createRunWithFindingInLine(10);
         $misuse = Misuse::find(1);
 
-        $this->createReview($misuse, $reviewer1, 'Yes');
-        $this->createReview($misuse, $reviewer2, 'No');
+        $this->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
+        $this->createReview($misuse, $reviewer2, 'No', [], ['reviewer2-tag']);
 
-        $tagController = new \MuBench\ReviewSite\Controllers\TagsController($this->container);
-        $tagController->addTagToMisuse($misuse->id, 'reviewer1-tag', $reviewer1->id);
-        $tagController->addTagToMisuse($misuse->id, 'reviewer2-tag', $reviewer2->id);
-
-        $tags = $misuse->getTags($reviewer1);
+        $tags = $misuse->getReview($reviewer1)->tags;
         self::assertEquals(1, $tags->count());
         self::assertEquals('reviewer1-tag', $tags[0]->name);
     }
@@ -146,12 +142,9 @@ class MisuseTest extends SlimTestCase
         $this->createRunWithFindingInLine(10);
         $misuse = Misuse::find(1);
 
-        $this->createReview($misuse, $reviewer1, 'Yes');
+        $this->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
 
-        $tagController = new \MuBench\ReviewSite\Controllers\TagsController($this->container);
-        $tagController->addTagToMisuse($misuse->id, 'reviewer1-tag', $reviewer1->id);
-
-        self::assertEquals(0, $misuse->getTags(null)->count());
+        self::assertEquals(0, $misuse->getTags()->count());
     }
 
     public function createRunWithFindingInLine($line)

--- a/mubench.reviewsite/tests/MisuseTest.php
+++ b/mubench.reviewsite/tests/MisuseTest.php
@@ -13,6 +13,16 @@ use MuBench\ReviewSite\Models\Snippet;
 
 class MisuseTest extends SlimTestCase
 {
+
+    /** @var ReviewsControllerHelper */
+    private $reviewsControllerHelper;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->reviewsControllerHelper = new ReviewsControllerHelper($this->container);
+    }
+
     public function testHasReviewed()
     {
         $reviewer = Reviewer::create(['name' => ':arbitrary:']);
@@ -110,8 +120,8 @@ class MisuseTest extends SlimTestCase
         $this->createRunWithFindingInLine(10);
         $misuse = Misuse::find(1);
 
-        $this->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
-        $this->createReview($misuse, $reviewer2, 'Yes', [], ['reviewer2-tag']);
+        $this->reviewsControllerHelper->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
+        $this->reviewsControllerHelper->createReview($misuse, $reviewer2, 'Yes', [], ['reviewer2-tag']);
 
         self::assertEquals(2, Misuse::find(1)->getTags()->count());
     }
@@ -124,8 +134,8 @@ class MisuseTest extends SlimTestCase
         $this->createRunWithFindingInLine(10);
         $misuse = Misuse::find(1);
 
-        $this->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
-        $this->createReview($misuse, $reviewer2, 'No', [], ['reviewer2-tag']);
+        $this->reviewsControllerHelper->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
+        $this->reviewsControllerHelper->createReview($misuse, $reviewer2, 'No', [], ['reviewer2-tag']);
 
         $tags = $misuse->getReview($reviewer1)->tags;
         self::assertEquals(1, $tags->count());
@@ -138,7 +148,7 @@ class MisuseTest extends SlimTestCase
         $this->createRunWithFindingInLine(10);
         $misuse = Misuse::find(1);
 
-        $this->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
+        $this->reviewsControllerHelper->createReview($misuse, $reviewer1, 'Yes', [], ['reviewer1-tag']);
 
         self::assertEquals(0, $misuse->getTags()->count());
     }

--- a/mubench.reviewsite/tests/MisuseTest.php
+++ b/mubench.reviewsite/tests/MisuseTest.php
@@ -1,9 +1,8 @@
 <?php
 
-use MuBench\ReviewSite\Controllers\MetadataController;
-use MuBench\ReviewSite\Controllers\ReviewsController;
+namespace MuBench\ReviewSite\Tests;
+
 use MuBench\ReviewSite\Controllers\RunsController;
-use MuBench\ReviewSite\Controllers\SnippetsController;
 use MuBench\ReviewSite\Models\Detector;
 use MuBench\ReviewSite\Models\Experiment;
 use MuBench\ReviewSite\Models\Misuse;
@@ -11,9 +10,6 @@ use MuBench\ReviewSite\Models\Review;
 use MuBench\ReviewSite\Models\Reviewer;
 use MuBench\ReviewSite\Models\Run;
 use MuBench\ReviewSite\Models\Snippet;
-
-require_once 'SlimTestCase.php';
-
 
 class MisuseTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/ReviewControllerTest.php
+++ b/mubench.reviewsite/tests/ReviewControllerTest.php
@@ -153,9 +153,4 @@ class ReviewControllerTest extends SlimTestCase
         $this->createReview($misuse, $this->reviewer2, "Yes");
     }
 
-    private function createReview($misuse, $reviewer, $hit, $violations = [])
-    {
-        $this->reviewController->updateOrCreateReview($misuse->id, $reviewer->id, '-comment-', [['hit' => $hit, 'violations' => $violations]]);
-    }
-
 }

--- a/mubench.reviewsite/tests/ReviewControllerTest.php
+++ b/mubench.reviewsite/tests/ReviewControllerTest.php
@@ -1,14 +1,12 @@
 <?php
 
-namespace MuBench\ReviewSite\Controllers;
+namespace MuBench\ReviewSite\Tests;
 
-require_once 'SlimTestCase.php';
-
+use MuBench\ReviewSite\Controllers\RunsController;
 use MuBench\ReviewSite\Models\Decision;
 use MuBench\ReviewSite\Models\Misuse;
 use MuBench\ReviewSite\Models\Reviewer;
 use MuBench\ReviewSite\Models\Violation;
-use SlimTestCase;
 
 class ReviewControllerTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/ReviewControllerTest.php
+++ b/mubench.reviewsite/tests/ReviewControllerTest.php
@@ -11,9 +11,9 @@ use MuBench\ReviewSite\Models\Violation;
 class ReviewControllerTest extends SlimTestCase
 {
     /**
-     * @var ReviewsController $reviewController
+     * @var ReviewsControllerHelper $reviewControllerHelper
      */
-    private $reviewController;
+    private $reviewControllerHelper;
 
     /**
      * @var Reviewer $reviewer1
@@ -28,7 +28,7 @@ class ReviewControllerTest extends SlimTestCase
     function setUp()
     {
         parent::setUp();
-        $this->reviewController = new ReviewsController($this->container);
+        $this->reviewControllerHelper = new ReviewsControllerHelper($this->container);
         $this->reviewer1 = Reviewer::create(['name' => 'reviewer1']);
         $this->reviewer2 = Reviewer::create(['name' => 'reviewer2']);
     }
@@ -38,7 +38,7 @@ class ReviewControllerTest extends SlimTestCase
     {
         $misuse = Misuse::create(['misuse_muid' => '0', 'run_id' => 2, 'detector_id' => 1]);
 
-        $this->createReview($misuse, $this->reviewer1, "Yes");
+        $this->reviewControllerHelper->createReview($misuse, $this->reviewer1, "Yes");
 
         $review = Misuse::find(1)->getReview($this->reviewer1);
         self::assertEquals('-comment-', $review->comment);
@@ -48,8 +48,8 @@ class ReviewControllerTest extends SlimTestCase
     {
         $misuse = Misuse::create(['misuse_muid' => '0', 'run_id' => 2, 'detector_id' => 1]);
 
-        $this->createReview($misuse, $this->reviewer1, "Yes");
-        $this->createReview($misuse, $this->reviewer1, "No");
+        $this->reviewControllerHelper->createReview($misuse, $this->reviewer1, "Yes");
+        $this->reviewControllerHelper->createReview($misuse, $this->reviewer1, "No");
 
         $review = Misuse::find(1)->getReview($this->reviewer1);
         self::assertEquals('-comment-', $review->comment);
@@ -61,7 +61,7 @@ class ReviewControllerTest extends SlimTestCase
         $misuse = Misuse::create(['misuse_muid' => '0', 'run_id' => 2, 'detector_id' => 1]);
         Violation::create(['name' => 'missing/call']);
 
-        $this->createReview($misuse, $this->reviewer1, "Yes", [1]);
+        $this->reviewControllerHelper->createReview($misuse, $this->reviewer1, "Yes", [1]);
 
         $review = Misuse::find(1)->getReview($this->reviewer1);
         $violations = $review->getHitViolations('0');
@@ -76,7 +76,7 @@ class ReviewControllerTest extends SlimTestCase
         $this->createConclusiveReviewState($misuse2);
 
         // current misuse = 1, reviewer = 1
-        list($previous_misuse, $next_misuse, $next_reviewable_misuse, $misuse)  = $this->reviewController->determineNavigationTargets(Misuse::all(), '-p-', '-v-', $misuse1->misuse_muid, $this->reviewer1);
+        list($previous_misuse, $next_misuse, $next_reviewable_misuse, $misuse)  = $this->reviewControllerHelper->reviewController->determineNavigationTargets(Misuse::all(), '-p-', '-v-', $misuse1->misuse_muid, $this->reviewer1);
 
         self::assertEquals($misuse3->misuse_muid, $previous_misuse->misuse_muid);
         self::assertEquals($misuse2->misuse_muid, $next_misuse->misuse_muid);
@@ -92,7 +92,7 @@ class ReviewControllerTest extends SlimTestCase
         $this->createConclusiveReviewState($misuse2);
 
         // current misuse = 3, reviewer = 1
-        list($previous_misuse, $next_misuse, $next_reviewable_misuse, $misuse)  = $this->reviewController->determineNavigationTargets(Misuse::all(), '-p-', '-v-', $misuse3->misuse_muid, $this->reviewer1);
+        list($previous_misuse, $next_misuse, $next_reviewable_misuse, $misuse)  = $this->reviewControllerHelper->reviewController->determineNavigationTargets(Misuse::all(), '-p-', '-v-', $misuse3->misuse_muid, $this->reviewer1);
 
         self::assertEquals($misuse2->misuse_muid, $previous_misuse->misuse_muid);
         self::assertEquals($misuse1->misuse_muid, $next_misuse->misuse_muid);
@@ -104,12 +104,12 @@ class ReviewControllerTest extends SlimTestCase
     {
         list($misuse1, $misuse2, $misuse3) = $this->createRunWithThreeMisuses();
 
-        $this->createReview($misuse1, $this->reviewer2, "Yes");
-        $this->createReview($misuse2, $this->reviewer1, "Yes");
-        $this->createReview($misuse3, $this->reviewer2, "Yes");
+        $this->reviewControllerHelper->createReview($misuse1, $this->reviewer2, "Yes");
+        $this->reviewControllerHelper->createReview($misuse2, $this->reviewer1, "Yes");
+        $this->reviewControllerHelper->createReview($misuse3, $this->reviewer2, "Yes");
 
         // current misuse = 1, reviewer = 1
-        list($previous_misuse, $next_misuse, $next_reviewable_misuse, $misuse)  = $this->reviewController->determineNavigationTargets(Misuse::all(), '-p-', '-v-', $misuse1->misuse_muid, $this->reviewer1);
+        list($previous_misuse, $next_misuse, $next_reviewable_misuse, $misuse)  = $this->reviewControllerHelper->reviewController->determineNavigationTargets(Misuse::all(), '-p-', '-v-', $misuse1->misuse_muid, $this->reviewer1);
 
         self::assertEquals($misuse3->misuse_muid, $previous_misuse->misuse_muid);
         self::assertEquals($misuse2->misuse_muid, $next_misuse->misuse_muid);
@@ -147,8 +147,8 @@ class ReviewControllerTest extends SlimTestCase
 
     private function createConclusiveReviewState($misuse)
     {
-        $this->createReview($misuse, $this->reviewer1, "Yes");
-        $this->createReview($misuse, $this->reviewer2, "Yes");
+        $this->reviewControllerHelper->createReview($misuse, $this->reviewer1, "Yes");
+        $this->reviewControllerHelper->createReview($misuse, $this->reviewer2, "Yes");
     }
 
 }

--- a/mubench.reviewsite/tests/ReviewStateTest.php
+++ b/mubench.reviewsite/tests/ReviewStateTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'SlimTestCase.php';
+namespace MuBench\ReviewSite\Tests;
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/mubench.reviewsite/tests/ReviewStateTest.php
+++ b/mubench.reviewsite/tests/ReviewStateTest.php
@@ -13,12 +13,17 @@ use MuBench\ReviewSite\Models\ReviewState;
 
 class ReviewStateTest extends SlimTestCase
 {
+
+    /** @var  ReviewsControllerHelper */
+    private $reviewsControllerHelper;
+
     /** @var  Detector */
     private $detector;
 
     function setUp()
     {
         parent::setUp();
+        $this->reviewsControllerHelper = new ReviewsControllerHelper($this->container);
         $this->detector = Detector::create(['muid' => 'test-detector']);
     }
 
@@ -127,14 +132,14 @@ class ReviewStateTest extends SlimTestCase
     private function someMisuseWithOneFindingAndReviewDecisions($decisions, $resolutionDecision = null)
     {
         $misuse = Misuse::create(['misuse_muid' => "test", 'run_id' => 1, 'detector_id' => $this->detector->id]);
-        $finding = $this->createFindingWith(Experiment::find(2), $this->detector, $misuse);
+        $finding = TestHelper::createFindingWith(Experiment::find(2), $this->detector, $misuse);
         $reviewController = new ReviewsController($this->container);
         foreach ($decisions as $index => $decision) {
             $reviewer = Reviewer::firstOrCreate(['name' => 'reviewer' . $index]);
-            $this->createReview($misuse, $reviewer, $decision);
+            $this->reviewsControllerHelper->createReview($misuse, $reviewer, $decision);
         }
         if ($resolutionDecision) {
-            $this->createReview($misuse, Reviewer::firstOrCreate(['name' => 'resolution']), $resolutionDecision);
+            $this->reviewsControllerHelper->createReview($misuse, Reviewer::firstOrCreate(['name' => 'resolution']), $resolutionDecision);
         }
 
         return $misuse;

--- a/mubench.reviewsite/tests/ReviewStateTest.php
+++ b/mubench.reviewsite/tests/ReviewStateTest.php
@@ -131,10 +131,10 @@ class ReviewStateTest extends SlimTestCase
         $reviewController = new ReviewsController($this->container);
         foreach ($decisions as $index => $decision) {
             $reviewer = Reviewer::firstOrCreate(['name' => 'reviewer' . $index]);
-            $reviewController->updateOrCreateReview($misuse->id, $reviewer->id, '', [['hit' => $decision, 'violations' => []]]);
+            $this->createReview($misuse, $reviewer, $decision);
         }
         if ($resolutionDecision) {
-            $reviewController->updateOrCreateReview($misuse->id, Reviewer::firstOrCreate(['name' => 'resolution'])->id, '', [['hit' => $resolutionDecision, 'violations' => []]]);
+            $this->createReview($misuse, Reviewer::firstOrCreate(['name' => 'resolution']), $resolutionDecision);
         }
 
         return $misuse;

--- a/mubench.reviewsite/tests/ReviewerTest.php
+++ b/mubench.reviewsite/tests/ReviewerTest.php
@@ -1,9 +1,8 @@
 <?php
 
+namespace MuBench\ReviewSite\Tests;
+
 use MuBench\ReviewSite\Models\Reviewer;
-
-require_once 'SlimTestCase.php';
-
 
 class ReviewerTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/ReviewsControllerHelper.php
+++ b/mubench.reviewsite/tests/ReviewsControllerHelper.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MuBench\ReviewSite\Tests;
+
+use MuBench\ReviewSite\Controllers\ReviewsController;
+
+class ReviewsControllerHelper
+{
+
+    /** @var ReviewsController */
+    public $reviewController;
+
+    public function __construct($container)
+    {
+        $this->reviewController = new ReviewsController($container);
+    }
+
+    function createReview($misuse, $reviewer, $hit, $violations = [], $tags = [])
+    {
+        $this->reviewController->updateOrCreateReview($misuse->id, $reviewer->id, '-comment-', [['hit' => $hit, 'violations' => $violations]], $tags);
+    }
+
+}

--- a/mubench.reviewsite/tests/RunsControllerTest.php
+++ b/mubench.reviewsite/tests/RunsControllerTest.php
@@ -490,12 +490,12 @@ class RunsControllerTest extends SlimTestCase
         $reviewController = new ReviewsController($this->container);
         foreach ($decisions as $index => $decision) {
             $reviewer = Reviewer::firstOrCreate(['name' => '-reviewer' . $index . '-']);
-            $reviewController->updateOrCreateReview($misuse->id, $reviewer->id, '-comment-', [['hit' => $decision, 'violations' => []]]);
+            $this->createReview($misuse, $reviewer, $decision);
         }
 
         if ($resolutionDecision) {
             $resolutionReviewer = Reviewer::where(['name' => 'resolution'])->first();
-            $reviewController->updateOrCreateReview($misuse->id, $resolutionReviewer->id, '-comment-', [['hit' => $resolutionDecision, 'violations' => []]]);
+            $this->createReview($misuse, $resolutionReviewer, $resolutionDecision);
         }
     }
 

--- a/mubench.reviewsite/tests/RunsControllerTest.php
+++ b/mubench.reviewsite/tests/RunsControllerTest.php
@@ -30,10 +30,14 @@ class RunsControllerTest extends SlimTestCase
     /** @var RunsController */
     private $runsController;
 
+    /** @var ReviewsControllerHelper */
+    private $reviewsControllerHelper;
+
     function setUp()
     {
         parent::setUp();
         $this->runsController = new RunsController($this->container);
+        $this->reviewsControllerHelper = new ReviewsControllerHelper($this->container);
         $this->detector1 = Detector::create(['muid' => '-d1-']);
         $this->detector2 = Detector::create(['muid' => '-d2-']);
 
@@ -472,7 +476,7 @@ class RunsControllerTest extends SlimTestCase
         $run->misuses = new Collection;
         foreach($misuses as $key => $misuse){
             $new_misuse = Misuse::create(['misuse_muid' => $key, 'run_id' => $run->id, 'detector_id' => $detector->id]);
-            $this->createFindingWith($experiment, $detector, $new_misuse);
+            TestHelper::createFindingWith($experiment, $detector, $new_misuse);
             $this->addReviewsForMisuse($new_misuse, $misuse[0], sizeof($misuse) > 1 ? $misuse[1] : null);
             $new_misuse->findings;
             $new_misuse->save();
@@ -486,12 +490,12 @@ class RunsControllerTest extends SlimTestCase
         $reviewController = new ReviewsController($this->container);
         foreach ($decisions as $index => $decision) {
             $reviewer = Reviewer::firstOrCreate(['name' => '-reviewer' . $index . '-']);
-            $this->createReview($misuse, $reviewer, $decision);
+            $this->reviewsControllerHelper->createReview($misuse, $reviewer, $decision);
         }
 
         if ($resolutionDecision) {
             $resolutionReviewer = Reviewer::where(['name' => 'resolution'])->first();
-            $this->createReview($misuse, $resolutionReviewer, $resolutionDecision);
+            $this->reviewsControllerHelper->createReview($misuse, $resolutionReviewer, $resolutionDecision);
         }
     }
 

--- a/mubench.reviewsite/tests/RunsControllerTest.php
+++ b/mubench.reviewsite/tests/RunsControllerTest.php
@@ -1,16 +1,12 @@
 <?php
 
-require_once "SlimTestCase.php";
+namespace MuBench\ReviewSite\Tests;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
-use MuBench\ReviewSite\Controllers\FindingsController;
-use MuBench\ReviewSite\Controllers\FindingsUploader;
 use MuBench\ReviewSite\Controllers\MetadataController;
-use MuBench\ReviewSite\Controllers\MisuseTagsController;
 use MuBench\ReviewSite\Controllers\ReviewsController;
 use MuBench\ReviewSite\Controllers\RunsController;
-use MuBench\ReviewSite\Controllers\SnippetUploader;
 use MuBench\ReviewSite\Models\Detector;
 use MuBench\ReviewSite\Models\DetectorResult;
 use MuBench\ReviewSite\Models\Experiment;

--- a/mubench.reviewsite/tests/SimpleDataTest.php
+++ b/mubench.reviewsite/tests/SimpleDataTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
+namespace MuBench\ReviewSite\Tests;
 
-require_once 'SlimTestCase.php';
+use Illuminate\Support\Facades\Schema;
 
 class SimpleDataTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/SlimTest.php
+++ b/mubench.reviewsite/tests/SlimTest.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once "SlimTestCase.php";
+namespace MuBench\ReviewSite\Tests;
 
 class SlimTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/SlimTestCase.php
+++ b/mubench.reviewsite/tests/SlimTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace MuBench\ReviewSite\Tests;
+
 use Illuminate\Container\Container;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/mubench.reviewsite/tests/SlimTestCase.php
+++ b/mubench.reviewsite/tests/SlimTestCase.php
@@ -144,40 +144,4 @@ class SlimTestCase extends TestCase
         $sqlite = str_replace(" ENGINE=MyISAM  DEFAULT CHARSET=latin1;", ";", $sqlite);
         return $sqlite;
     }
-
-    protected function createFindingWith($experiment, $detector, $misuse)
-    {
-        $finding = new \MuBench\ReviewSite\Models\Finding;
-        $finding->setDetector($detector);
-        Schema::dropIfExists($finding->getTable());
-        if(!Schema::hasTable($finding->getTable())){
-            Schema::create($finding->getTable(), function (Blueprint $table) {
-                $table->increments('id');
-                $table->integer('experiment_id');
-                $table->integer('misuse_id');
-                $table->string('project_muid', 30);
-                $table->string('version_muid', 30);
-                $table->string('misuse_muid', 30);
-                $table->integer('startline');
-                $table->integer('rank');
-                $table->integer('additional_column')->nullable();
-                $table->text('file');
-                $table->text('method');
-                $table->dateTime('created_at');
-                $table->dateTime('updated_at');
-            });
-        }
-
-        $finding->experiment_id = $experiment->id;
-        $finding->misuse_id = $misuse->id;
-        $finding->project_muid = 'mubench';
-        $finding->version_muid = '42';
-        $finding->misuse_muid = '0';
-        $finding->startline = 113;
-        $finding->rank = 1;
-        $finding->file = 'Test.java';
-        $finding->method = "method(A)";
-        $finding->save();
-    }
-
 }

--- a/mubench.reviewsite/tests/SlimTestCase.php
+++ b/mubench.reviewsite/tests/SlimTestCase.php
@@ -180,9 +180,4 @@ class SlimTestCase extends TestCase
         $finding->save();
     }
 
-    function createReview($misuse, $reviewer, $hit, $violations = [], $tags = [])
-    {
-        $reviewController = new \MuBench\ReviewSite\Controllers\ReviewsController($this->container);
-        $reviewController->updateOrCreateReview($misuse->id, $reviewer->id, '-comment-', [['hit' => $hit, 'violations' => $violations]], $tags);
-    }
 }

--- a/mubench.reviewsite/tests/SlimTestCase.php
+++ b/mubench.reviewsite/tests/SlimTestCase.php
@@ -177,4 +177,10 @@ class SlimTestCase extends TestCase
         $finding->method = "method(A)";
         $finding->save();
     }
+
+    function createReview($misuse, $reviewer, $hit, $violations = [])
+    {
+        $reviewController = new \MuBench\ReviewSite\Controllers\ReviewsController($this->container);
+        $reviewController->updateOrCreateReview($misuse->id, $reviewer->id, '-comment-', [['hit' => $hit, 'violations' => $violations]]);
+    }
 }

--- a/mubench.reviewsite/tests/SlimTestCase.php
+++ b/mubench.reviewsite/tests/SlimTestCase.php
@@ -178,9 +178,9 @@ class SlimTestCase extends TestCase
         $finding->save();
     }
 
-    function createReview($misuse, $reviewer, $hit, $violations = [])
+    function createReview($misuse, $reviewer, $hit, $violations = [], $tags = [])
     {
         $reviewController = new \MuBench\ReviewSite\Controllers\ReviewsController($this->container);
-        $reviewController->updateOrCreateReview($misuse->id, $reviewer->id, '-comment-', [['hit' => $hit, 'violations' => $violations]]);
+        $reviewController->updateOrCreateReview($misuse->id, $reviewer->id, '-comment-', [['hit' => $hit, 'violations' => $violations]], $tags);
     }
 }

--- a/mubench.reviewsite/tests/SnippetControllerTest.php
+++ b/mubench.reviewsite/tests/SnippetControllerTest.php
@@ -1,9 +1,9 @@
 <?php
 
+namespace MuBench\ReviewSite\Tests;
+
 use MuBench\ReviewSite\Controllers\SnippetsController;
 use MuBench\ReviewSite\Models\Snippet;
-
-require_once 'SlimTestCase.php';
 
 class SnippetControllerTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/TagControllerTest.php
+++ b/mubench.reviewsite/tests/TagControllerTest.php
@@ -6,6 +6,8 @@ require_once "SlimTestCase.php";
 
 use DatabaseTestCase;
 use MuBench\ReviewSite\Models\Misuse;
+use MuBench\ReviewSite\Models\Review;
+use MuBench\ReviewSite\Models\Reviewer;
 use MuBench\ReviewSite\Models\Tag;
 use SlimTestCase;
 
@@ -15,65 +17,61 @@ class TagControllerTest extends SlimTestCase
     private $tagController;
 
     /** @var  Misuse */
-    private $misuse;
+    private $review;
 
     function setUp()
     {
         parent::setUp();
-        $this->tagController = new TagsController($this->container);
+        $reviewer = Reviewer::create(['name' => 'reviewer']);
         $misuse = new Misuse;
         $misuse->metadata_id = 1;
         $misuse->misuse_muid = '1';
         $misuse->run_id = 1;
         $misuse->detector_id = 42;
         $misuse->save();
+        $this->createReview($misuse, $reviewer, 'Yes');
+        $this->review = Review::find(1);
+        $this->tagController = new TagsController($this->container);
     }
 
-    function test_save_misuse_tags()
+    function test_save_review_tags()
     {
-        $this->tagController->addTagToMisuse(1, 'test-dataset', 1);
+        TagsController::syncReviewTags($this->review->id, ['test-dataset']);
 
-        $misuseTags = Misuse::find(1)->misuse_tags;
+        $reviewTags = $this->review->tags;
 
-        self::assertEquals('test-dataset', $misuseTags->first()->name);
-        self::assertEquals(1, $misuseTags->first()->pivot->reviewer_id);
+        self::assertEquals('test-dataset', $reviewTags->first()->name);
     }
 
-    function test_delete_misuse_tag()
+    function test_delete_review_tag()
     {
-        $this->tagController->addTagToMisuse(1, 'test-dataset', 1);
-        $this->tagController->addTagToMisuse(1, 'test-dataset', 2);
-        $this->tagController->deleteTagFromMisuse(1, 2, 2);
+        TagsController::syncReviewTags($this->review->id, ['test-dataset', 'test-dataset2']);
+        TagsController::deleteTagFromReview($this->review->id, 1);
 
-        $misuseTags = Misuse::find(1)->misuse_tags;
+        $reviewTags = $this->review->tags;
 
-        self::assertEquals(1, $misuseTags->count());
-        self::assertEquals('test-dataset', $misuseTags->first()->name);
-        self::assertEquals(1, $misuseTags->first()->pivot->reviewer_id);
+        self::assertEquals(1, $reviewTags->count());
+        self::assertEquals('test-dataset2', $reviewTags->first()->name);
     }
 
     function test_adding_same_tag_twice()
     {
-        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
-        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
+        TagsController::syncReviewTags($this->review->id, ['test-tag']);
+        TagsController::syncReviewTags($this->review->id, ['test-tag']);
 
-        $misuseTags = Misuse::find(1)->misuse_tags;
-
-        self::assertEquals(1, count($misuseTags));
+        self::assertEquals(1, $this->review->tags->count());
     }
 
     function test_add_unknown_tag()
     {
-        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
+        TagsController::syncReviewTags($this->review->id, ['test-tag']);
 
-        $misuseTags = Misuse::find(1)->misuse_tags;
-
-        self::assertEquals('test-tag', $misuseTags->get(0)->name);
+        self::assertEquals('test-tag', $this->review->tags[0]->name);
     }
 
     function test_update_tag()
     {
-        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
+        TagsController::syncReviewTags($this->review->id, ['test-tag']);
 
         $tag = Tag::where('name', 'test-tag')->first();
         $tag_id = $tag->id;
@@ -87,12 +85,12 @@ class TagControllerTest extends SlimTestCase
 
     function test_delete_tag()
     {
-        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
+        TagsController::syncReviewTags($this->review->id, ['test-tag']);
         $tag_id = Tag::where('name', 'test-tag')->first()->id;
 
 
-        $this->tagController->deleteTagAndRemoveFromMisuses($tag_id);
-        self::assertEmpty(Misuse::find(1)->misuse_tags);
+        $this->tagController->deleteTagAndRemoveFromReviews($tag_id);
+        self::assertEmpty($this->review->tags);
         self::assertNull(Tag::find($tag_id));
     }
 }

--- a/mubench.reviewsite/tests/TagControllerTest.php
+++ b/mubench.reviewsite/tests/TagControllerTest.php
@@ -31,26 +31,31 @@ class TagControllerTest extends SlimTestCase
 
     function test_save_misuse_tags()
     {
-        $this->tagController->addTagToMisuse(1, 'test-dataset');
+        $this->tagController->addTagToMisuse(1, 'test-dataset', 1);
 
         $misuseTags = Misuse::find(1)->misuse_tags;
 
-        self::assertEquals('test-dataset', $misuseTags->get(0)->name);
+        self::assertEquals('test-dataset', $misuseTags->first()->name);
+        self::assertEquals(1, $misuseTags->first()->pivot->reviewer_id);
     }
 
     function test_delete_misuse_tag()
     {
-        $this->tagController->deleteTagFromMisuse(1, 2);
+        $this->tagController->addTagToMisuse(1, 'test-dataset', 1);
+        $this->tagController->addTagToMisuse(1, 'test-dataset', 2);
+        $this->tagController->deleteTagFromMisuse(1, 2, 2);
 
         $misuseTags = Misuse::find(1)->misuse_tags;
 
-        self::assertEmpty($misuseTags);
+        self::assertEquals(1, $misuseTags->count());
+        self::assertEquals('test-dataset', $misuseTags->first()->name);
+        self::assertEquals(1, $misuseTags->first()->pivot->reviewer_id);
     }
 
     function test_adding_same_tag_twice()
     {
-        $this->tagController->addTagToMisuse(1, 'test-tag');
-        $this->tagController->addTagToMisuse(1, 'test-tag');
+        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
+        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
 
         $misuseTags = Misuse::find(1)->misuse_tags;
 
@@ -59,7 +64,7 @@ class TagControllerTest extends SlimTestCase
 
     function test_add_unknown_tag()
     {
-        $this->tagController->addTagToMisuse(1, 'test-tag');
+        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
 
         $misuseTags = Misuse::find(1)->misuse_tags;
 
@@ -68,7 +73,7 @@ class TagControllerTest extends SlimTestCase
 
     function test_update_tag()
     {
-        $this->tagController->addTagToMisuse(1, 'test-tag');
+        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
 
         $tag = Tag::where('name', 'test-tag')->first();
         $tag_id = $tag->id;
@@ -82,7 +87,7 @@ class TagControllerTest extends SlimTestCase
 
     function test_delete_tag()
     {
-        $this->tagController->addTagToMisuse(1, 'test-tag');
+        $this->tagController->addTagToMisuse(1, 'test-tag', 1);
         $tag_id = Tag::where('name', 'test-tag')->first()->id;
 
 

--- a/mubench.reviewsite/tests/TagControllerTest.php
+++ b/mubench.reviewsite/tests/TagControllerTest.php
@@ -19,6 +19,7 @@ class TagControllerTest extends SlimTestCase
     function setUp()
     {
         parent::setUp();
+        $reviewsControllerHelper = new ReviewsControllerHelper($this->container);
         $reviewer = Reviewer::create(['name' => 'reviewer']);
         $misuse = new Misuse;
         $misuse->metadata_id = 1;
@@ -26,7 +27,7 @@ class TagControllerTest extends SlimTestCase
         $misuse->run_id = 1;
         $misuse->detector_id = 42;
         $misuse->save();
-        $this->createReview($misuse, $reviewer, 'Yes');
+        $reviewsControllerHelper->createReview($misuse, $reviewer, 'Yes');
         $this->review = Review::find(1);
         $this->tagController = new TagsController($this->container);
     }

--- a/mubench.reviewsite/tests/TagControllerTest.php
+++ b/mubench.reviewsite/tests/TagControllerTest.php
@@ -1,15 +1,12 @@
 <?php
 
-namespace MuBench\ReviewSite\Controllers;
+namespace MuBench\ReviewSite\Tests;
 
-require_once "SlimTestCase.php";
-
-use DatabaseTestCase;
+use MuBench\ReviewSite\Controllers\TagsController;
 use MuBench\ReviewSite\Models\Misuse;
 use MuBench\ReviewSite\Models\Review;
 use MuBench\ReviewSite\Models\Reviewer;
 use MuBench\ReviewSite\Models\Tag;
-use SlimTestCase;
 
 class TagControllerTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/TagTest.php
+++ b/mubench.reviewsite/tests/TagTest.php
@@ -1,8 +1,8 @@
 <?php
 
-use MuBench\ReviewSite\Models\Tag;
+namespace MuBench\ReviewSite\Tests;
 
-require_once 'SlimTestCase.php';
+use MuBench\ReviewSite\Models\Tag;
 
 class TagTest extends SlimTestCase
 {

--- a/mubench.reviewsite/tests/TestHelper.php
+++ b/mubench.reviewsite/tests/TestHelper.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MuBench\ReviewSite\Tests;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use MuBench\ReviewSite\Models\Finding;
+
+class TestHelper
+{
+    public static function createFindingWith($experiment, $detector, $misuse)
+    {
+        $finding = new Finding;
+        $finding->setDetector($detector);
+        Schema::dropIfExists($finding->getTable());
+        if(!Schema::hasTable($finding->getTable())){
+            Schema::create($finding->getTable(), function (Blueprint $table) {
+                $table->increments('id');
+                $table->integer('experiment_id');
+                $table->integer('misuse_id');
+                $table->string('project_muid', 30);
+                $table->string('version_muid', 30);
+                $table->string('misuse_muid', 30);
+                $table->integer('startline');
+                $table->integer('rank');
+                $table->integer('additional_column')->nullable();
+                $table->text('file');
+                $table->text('method');
+                $table->dateTime('created_at');
+                $table->dateTime('updated_at');
+            });
+        }
+
+        $finding->experiment_id = $experiment->id;
+        $finding->misuse_id = $misuse->id;
+        $finding->project_muid = 'mubench';
+        $finding->version_muid = '42';
+        $finding->misuse_muid = '0';
+        $finding->startline = 113;
+        $finding->rank = 1;
+        $finding->file = 'Test.java';
+        $finding->method = "method(A)";
+        $finding->save();
+    }
+}

--- a/mubench.reviewsite/tests/create_simple_test_data.php
+++ b/mubench.reviewsite/tests/create_simple_test_data.php
@@ -451,6 +451,6 @@ $tag->color = '#808080';
 $tag->save();
 
 echo 'Creating MisuseTags<br/>';
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 1, 'reviewer_id' => $reviewer1->id));
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 1, 'tag_id' => 2, 'reviewer_id' => $reviewer2->id));
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 2, 'reviewer_id' => $reviewer2->id));
+$capsule->table('review_tags')->insert(array('review_id' => 3, 'tag_id' => 1));
+$capsule->table('review_tags')->insert(array('review_id' => 1, 'tag_id' => 2));
+$capsule->table('review_tags')->insert(array('review_id' => 3, 'tag_id' => 2));

--- a/mubench.reviewsite/tests/create_simple_test_data.php
+++ b/mubench.reviewsite/tests/create_simple_test_data.php
@@ -451,6 +451,6 @@ $tag->color = '#808080';
 $tag->save();
 
 echo 'Creating MisuseTags<br/>';
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 1, 'reviewer_id' => $reviewer->id));
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 1, 'tag_id' => 2, 'reviewer_id' => $reviewer->id));
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 2, 'reviewer_id' => $reviewer->id));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 1, 'reviewer_id' => 2));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 1, 'tag_id' => 2, 'reviewer_id' => 3));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 2, 'reviewer_id' => 3));

--- a/mubench.reviewsite/tests/create_simple_test_data.php
+++ b/mubench.reviewsite/tests/create_simple_test_data.php
@@ -394,15 +394,15 @@ $review->save();
 
 
 echo 'Creating reviewers<br/>';
-$reviewer = new \MuBench\ReviewSite\Models\Reviewer;
-$reviewer->name = 'reviewer';
-$reviewer->save();
-$reviewer = new \MuBench\ReviewSite\Models\Reviewer;
-$reviewer->name = 'reviewer2';
-$reviewer->save();
-$reviewer = new \MuBench\ReviewSite\Models\Reviewer;
-$reviewer->name = 'admin';
-$reviewer->save();
+$reviewer1 = new \MuBench\ReviewSite\Models\Reviewer;
+$reviewer1->name = 'reviewer';
+$reviewer1->save();
+$reviewer2 = new \MuBench\ReviewSite\Models\Reviewer;
+$reviewer2->name = 'reviewer2';
+$reviewer2->save();
+$reviewer3 = new \MuBench\ReviewSite\Models\Reviewer;
+$reviewer3->name = 'admin';
+$reviewer3->save();
 
 
 echo 'Creating finding reviews<br/>';
@@ -451,6 +451,6 @@ $tag->color = '#808080';
 $tag->save();
 
 echo 'Creating MisuseTags<br/>';
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 1, 'reviewer_id' => 2));
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 1, 'tag_id' => 2, 'reviewer_id' => 3));
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 2, 'reviewer_id' => 3));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 1, 'reviewer_id' => $reviewer1->id));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 1, 'tag_id' => 2, 'reviewer_id' => $reviewer2->id));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 2, 'reviewer_id' => $reviewer2->id));

--- a/mubench.reviewsite/tests/create_simple_test_data.php
+++ b/mubench.reviewsite/tests/create_simple_test_data.php
@@ -451,6 +451,6 @@ $tag->color = '#808080';
 $tag->save();
 
 echo 'Creating MisuseTags<br/>';
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 1));
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 1, 'tag_id' => 2));
-$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 2));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 1, 'reviewer_id' => $reviewer->id));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 1, 'tag_id' => 2, 'reviewer_id' => $reviewer->id));
+$capsule->table('misuse_tags')->insert(array('misuse_id' => 3, 'tag_id' => 2, 'reviewer_id' => $reviewer->id));


### PR DESCRIPTION
I added a pivot column for the reviewer id to the tags. This enables us to show personal tags only on the review page when the review isn't conclusive yet. On the detector page we already show tags only when we have a conclusive review decision for a misuse. Should we change this to personal tags as well until we have a conclusive review or keep the current state?