### PR TITLE
Resolve #355: Provide a ./mubench debug command

### DIFF
--- a/data/testng/versions/677302c/version.yml
+++ b/data/testng/versions/677302c/version.yml
@@ -9,5 +9,4 @@ misuses:
 - 'dmmc-4'
 - 'grouminer-4'
 - 'grouminer-17'
-- 'mudetect-15'
 revision: 677302cb8b5a2507df97c5822eef3a03ebc4e23a^1

--- a/mubench.bin/debug
+++ b/mubench.bin/debug
@@ -1,0 +1,7 @@
+SRC=$(dirname $1)
+FILENAME=$(basename -- $1)
+DNAME=${FILENAME%.*}
+TARGET="/mubench/detectors/${DNAME}/debug"
+shift
+
+docker run --rm -v "$MUBENCH_ROOT":/mubench -v ${MUBENCH_PIPELINE_CHECKOUTS_VOLUME}:/mubench/checkouts -v ${MUBENCH_PIPELINE_FINDINGS_VOLUME}:/mubench/findings -v "${SRC}":"${TARGET}" -p 5005:5005 ${MUBENCH_PIPELINE_DOCKER_IMAGE} python ./mubench.pipeline/benchmark.py run $1 ${DNAME} ${*:2} --force-detect --tag debug --java-options agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005

--- a/mubench.bin/debug
+++ b/mubench.bin/debug
@@ -4,4 +4,17 @@ DNAME=${FILENAME%.*}
 TARGET="/mubench/detectors/${DNAME}/debug"
 shift
 
-docker run --rm -v "$MUBENCH_ROOT":/mubench -v ${MUBENCH_PIPELINE_CHECKOUTS_VOLUME}:/mubench/checkouts -v ${MUBENCH_PIPELINE_FINDINGS_VOLUME}:/mubench/findings -v "${SRC}":"${TARGET}" -p 5005:5005 ${MUBENCH_PIPELINE_DOCKER_IMAGE} python ./mubench.pipeline/benchmark.py run $1 ${DNAME} ${*:2} --force-detect --tag debug --java-options agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005
+TMP_DEBUG_DIR="${MUBENCH_ROOT}/tmp/"
+mkdir -p "${TMP_DEBUG_DIR}"
+RELEASES_DEBUG="${TMP_DEBUG_DIR}/releases.yml"
+touch "${RELEASES_DEBUG}"
+
+cat > "${RELEASES_DEBUG}" <<EOL
+- tag: debug
+  cli_version: $1
+EOL
+shift
+
+RELEASES_TARGET="/mubench/detectors/${DNAME}/releases.yml"
+
+docker run --rm -v "$MUBENCH_ROOT":/mubench -v ${MUBENCH_PIPELINE_CHECKOUTS_VOLUME}:/mubench/checkouts -v ${MUBENCH_PIPELINE_FINDINGS_VOLUME}:/mubench/findings -v "${SRC}":"${TARGET}" -v "${RELEASES_DEBUG}":"${RELEASES_TARGET}" -p 5005:5005 ${MUBENCH_PIPELINE_DOCKER_IMAGE} python ./mubench.pipeline/benchmark.py run $1 ${DNAME} ${*:2} --force-detect --tag debug --java-options agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005


### PR DESCRIPTION
Resolve #355: Provide a ./mubench debug command

Example usage with DemoDetector:
`./mubench debug /mubench/mubench.cli/target/DemoDetector.jar ex2 --only aclang`

Also, the script uses the `debug` tag, which is now handled by the detector implementation. This makes sure we don't "override" any "real" detectors.

We implicitly add the `--tag debug --force-detect` and `run` to the command for a bit more convenience.