### PR TITLE
Fix conditions in mubench script

### DIFF
--- a/mubench
+++ b/mubench
@@ -11,7 +11,7 @@ if [[ "$*" =~ "-h" ]]; then
   HELP=t
 fi
 
-if [ $HELP ] && [ $# = 1 ]; then
+if (( $HELP )) && (( $# -eq 1 )); then
   docker run --rm -v "$MUBENCH_ROOT":/mubench ${MUBENCH_PIPELINE_DOCKER_IMAGE} python3 ${MUBENCH_DOCS}/mubench.py "$@"
   exit 0
 else
@@ -19,7 +19,7 @@ else
   DOC="${MUBENCH_DOCS}/$1.py"
   if [ -f "${TASK}" ]; then
     shift  # remove requested task argument
-    if [ $HELP ] && [ -f "${MUBENCH_ROOT}/${DOC}" ]; then
+    if (( $HELP )) && (( -f "${MUBENCH_ROOT}/${DOC}" )); then
       docker run --rm -v "$MUBENCH_ROOT":/mubench ${MUBENCH_PIPELINE_DOCKER_IMAGE} python3 ${DOC} "$@"
       exit 0
     fi;


### PR DESCRIPTION
I noticed that with the previous version of the script, we would constantly run into help when one argument was passed (e.g. `./mubench browse`), because the `&&` conditions didn't work correctly.

I'm not sure if this is the correct way to do this, but it works for me. 