### PR TITLE
Resolve #389: TaskRunner should capture BaseException

### DIFF
--- a/mubench.pipeline/tasks/task_runner.py
+++ b/mubench.pipeline/tasks/task_runner.py
@@ -33,7 +33,7 @@ class TaskRunner:
 
         try:
             results = task.run(*parameter_values)
-        except Exception as exception:
+        except BaseException as exception:
             logger = logging.getLogger("task_runner.{}".format(task_name))
             logger.warning("Exception in %s: %s", task_name, exception)
             logger.debug("Full exception:", exc_info=True)

--- a/mubench.pipeline/tasks/task_runner.py
+++ b/mubench.pipeline/tasks/task_runner.py
@@ -35,7 +35,7 @@ class TaskRunner:
             results = task.run(*parameter_values)
         except BaseException as exception:
             logger = logging.getLogger("task_runner.{}".format(task_name))
-            logger.warning("Exception in %s: %s", task_name, exception)
+            logger.error("Exception in %s: %s", task_name, exception)
             logger.debug("Full exception:", exc_info=True)
             return
 


### PR DESCRIPTION
Resolve #389: TaskRunner should capture BaseException

Changes as discussed. We now catch `BaseException` and log exceptions as errors.

I've noticed that the giant error message from publish was actually due to a catch in the publish task. Turns out that getting a concise error message out of the `RequestException` is a bit tricky, since it seems to collect everything that happens during sending and mashes it all into one huge string, wrapped with another exception. 

I've implemented a custom exception that gets the reasons out `RequestException` and is printed into a per line listing of these reasons. In case of the `http://localhost` test, this gives us 
`[ERROR  ] Exception in PublishFindingsTask: Failed to establish a new connection: [Errno 111] Connection refused`
which I find much cleaner.

As always, the full exception info is printed into the log file.

Since I cannot thoroughly test this, I can't guarantee that this works for other fail cases as well. However, even if constructing our exception should fail and a confusing error message is printed, we will still have the original exception info available in the log file, in addition to why this logic failed.