### PR TITLE
Fix 430

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM anapsix/alpine-java:8_jdk
+FROM openjdk:8-jdk-alpine
+
 
 LABEL maintainer="amann@st.informatik.tu-darmstadt.de"
 
@@ -31,6 +32,7 @@ RUN apk update \
       graphviz \
       maven \
       subversion \
+      bash \
  \
  # Install gradle
  && wget -q https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip \

--- a/docker/Dockerfile_ci
+++ b/docker/Dockerfile_ci
@@ -7,8 +7,8 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV LANG=C.UTF-8 \
     GRADLE_VERSION=4.0.2 \
     GRADLE_HOME=/usr/local/gradle
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
-ENV PATH $PATH:$JAVA_HOME/bin
+#ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+#ENV PATH $PATH:$JAVA_HOME/bin
 
 # Setup container environment
 RUN apt-get clean \
@@ -22,13 +22,8 @@ RUN apt-get clean \
       && locale-gen en_US en_US.UTF-8 \
       && dpkg-reconfigure locales \
       && echo "APT::Get::Assume-Yes \"true\";\nAPT::Get::force-yes \"true\";" >> /etc/apt/apt.conf.d/90forceyes \
-      && add-apt-repository ppa:webupd8team/java \
-      && apt-get update \
-      && echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
-      && apt-get install -y oracle-java8-installer \
-      && update-alternatives --set java "$JAVA_HOME/jre/bin/java" \
-      && update-alternatives --set javac "$JAVA_HOME/bin/javac" \
-      && update-alternatives --set javaws "$JAVA_HOME/jre/bin/javaws" \
+      && apt-get install openjdk-8-jdk \
+      && apt-get install wget \
       && apt-get clean \
       && apt-get autoclean \
       && apt-get autoremove

--- a/docker/Dockerfile_ci
+++ b/docker/Dockerfile_ci
@@ -7,8 +7,6 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV LANG=C.UTF-8 \
     GRADLE_VERSION=4.0.2 \
     GRADLE_HOME=/usr/local/gradle
-#ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
-#ENV PATH $PATH:$JAVA_HOME/bin
 
 # Setup container environment
 RUN apt-get clean \


### PR DESCRIPTION
Change both dockerfiles (MUBench docker and docker_ci) to support openjdk 8 instead of Oracle jdk 8.


Tested to build both docker containers with:
```
docker build --file ./docker/Dockerfile .
docker build --file ./docker/Dockerfile_ci .
```

Tested to run both docker containers with:
```
docker run -it $IMAGE_ID_Docker_CI
docker run -it $IMAGE_ID_Docker
```

For the latter one, I tried some commands, e.g., checkout and compile. 