### PR TITLE
Update ArgoUML url

### DIFF
--- a/data/argouml/project.yml
+++ b/data/argouml/project.yml
@@ -1,5 +1,5 @@
 name: Argouml
 repository:
-  type: svn
-  url: http://argouml.tigris.org/svn/argouml/trunk
-url: http://argouml.tigris.org/
+  type: git
+  url: https://github.com/argouml-tigris-org/argouml.git
+url: https://github.com/argouml-tigris-org/argouml

--- a/data/argouml/versions/026/version.yml
+++ b/data/argouml/versions/026/version.yml
@@ -8,4 +8,4 @@ misuses:
 - 'tikanga11-2'
 - 'tikanga11-3'
 - 'tikanga11-4'
-revision: 15810
+revision: f787ce1018bbbf3e913a9987dd5d28a61e525cec


### PR DESCRIPTION
ArgoUML's old web site seems to be down:

![image](https://user-images.githubusercontent.com/17970732/81479615-81d35000-91e1-11ea-80d0-43ac1ec6b997.png)

However, they seemed to have migrated to [GitHub](https://github.com/argouml-tigris-org/argouml). 

This PR updates the link from the old svn repo to the new git repo of ArgoUML.